### PR TITLE
Move several combinator to trials

### DIFF
--- a/src/main/scala/com/sageserpent/americium/RandomEnrichment.scala
+++ b/src/main/scala/com/sageserpent/americium/RandomEnrichment.scala
@@ -500,7 +500,7 @@ trait RandomEnrichment {
         pickAnItem(streams)
       }
 
-    def splitIntoNonEmptyPieces[Container[Item] <: Iterable[Item], Item](
+    def splitIntoNonEmptyPieces[Container[X] <: Iterable[X], Item](
         items: Container[Item]
     ): LazyList[Container[Item]] = {
       val numberOfItems = items.size

--- a/src/main/scala/com/sageserpent/americium/RandomEnrichment.scala
+++ b/src/main/scala/com/sageserpent/americium/RandomEnrichment.scala
@@ -500,9 +500,7 @@ trait RandomEnrichment {
         pickAnItem(streams)
       }
 
-    def splitIntoNonEmptyPieces[Container[Element] <: Iterable[
-      Element
-    ] forSome { type Element }, X](
+    def splitIntoNonEmptyPieces[Container[X] <: Iterable[X], X](
         items: Container[X]
     ): LazyList[Container[X]] = {
       val numberOfItems = items.size

--- a/src/main/scala/com/sageserpent/americium/RandomEnrichment.scala
+++ b/src/main/scala/com/sageserpent/americium/RandomEnrichment.scala
@@ -500,9 +500,9 @@ trait RandomEnrichment {
         pickAnItem(streams)
       }
 
-    def splitIntoNonEmptyPieces[Container[X] <: Iterable[X], X](
-        items: Container[X]
-    ): LazyList[Container[X]] = {
+    def splitIntoNonEmptyPieces[Container[Item] <: Iterable[Item], Item](
+        items: Container[Item]
+    ): LazyList[Container[Item]] = {
       val numberOfItems = items.size
       if (0 < numberOfItems) {
         val numberOfSplitsDesired = chooseAnyNumberFromOneTo(numberOfItems)
@@ -513,19 +513,22 @@ trait RandomEnrichment {
 
         def splits(
             indicesToSplitAt: LazyList[Int],
-            items: Container[X],
+            items: Container[Item],
             indexOfPreviousSplit: Int
-        ): LazyList[Container[X]] =
+        ): LazyList[Container[Item]] =
           indicesToSplitAt match {
             case LazyList() =>
               if (items.isEmpty) LazyList.empty
               else LazyList(items)
             case indexToSplitAt #:: remainingIndicesToSplitAt =>
-              val (splitPiece, remainingItems) =
+              val (
+                splitPiece: Container[Item],
+                remainingItems: Container[Item]
+              ) =
                 items splitAt (indexToSplitAt - indexOfPreviousSplit)
-              splitPiece.asInstanceOf[Container[X]] #:: splits(
+              splitPiece #:: splits(
                 remainingIndicesToSplitAt,
-                remainingItems.asInstanceOf[Container[X]],
+                remainingItems,
                 indexToSplitAt
               )
           }

--- a/src/main/scala/com/sageserpent/americium/SeqEnrichment.scala
+++ b/src/main/scala/com/sageserpent/americium/SeqEnrichment.scala
@@ -5,7 +5,7 @@ import scala.collection.immutable.List
 import scala.language.postfixOps
 
 trait SeqEnrichment {
-  implicit class RichSeq[Container[Item] <: Seq[Item], Item](
+  implicit class RichSeq[Container[X] <: Seq[X], Item](
       items: Container[Item]
   ) {
     def groupWhile(predicate: (Item, Item) => Boolean)(implicit
@@ -35,7 +35,7 @@ trait SeqEnrichment {
   }
 
   implicit class RichSequenceOfSequences[
-      Container[Item],
+      Container[_],
       InnerContainer[Subelement] <: Iterable[Subelement],
       Subelement
   ](innerSequences: Container[InnerContainer[Subelement]]) {

--- a/src/main/scala/com/sageserpent/americium/Trials.scala
+++ b/src/main/scala/com/sageserpent/americium/Trials.scala
@@ -5,6 +5,7 @@ import com.sageserpent.americium.Trials.WithLimit
 import com.sageserpent.americium.TrialsImplementation.GenerationSupport
 import com.sageserpent.americium.java.TrialsFactoring
 
+import scala.collection.Factory
 import scala.language.implicitConversions
 
 object Trials extends TrialsByMagnolia {
@@ -15,7 +16,7 @@ object Trials extends TrialsByMagnolia {
   }
 
   implicit val monadInstance: Monad[Trials] = new Monad[Trials]
-  with StackSafeMonad[Trials] {
+    with StackSafeMonad[Trials] {
     override def pure[A](x: A): Trials[A] = api.only(x)
 
     override def flatMap[A, B](fa: Trials[A])(f: A => Trials[B]): Trials[B] =
@@ -27,24 +28,31 @@ object Trials extends TrialsByMagnolia {
       override def functor: Functor[Trials] = monadInstance
 
       override def mapFilter[A, B](fa: Trials[A])(
-          f: A => Option[B]): Trials[B] = fa.mapFilter(f)
+          f: A => Option[B]
+      ): Trials[B] = fa.mapFilter(f)
     }
 }
 
 trait Trials[+Case] extends TrialsFactoring[Case] with GenerationSupport[Case] {
   def map[TransformedCase](
-      transform: Case => TransformedCase): Trials[TransformedCase]
+      transform: Case => TransformedCase
+  ): Trials[TransformedCase]
 
   def flatMap[TransformedCase](
-      step: Case => Trials[TransformedCase]): Trials[TransformedCase]
+      step: Case => Trials[TransformedCase]
+  ): Trials[TransformedCase]
 
   def filter(predicate: Case => Boolean): Trials[Case]
 
   def mapFilter[TransformedCase](
-      filteringTransform: Case => Option[TransformedCase])
-    : Trials[TransformedCase]
+      filteringTransform: Case => Option[TransformedCase]
+  ): Trials[TransformedCase]
 
   def withLimit(limit: Int): WithLimit[Case]
 
   def supplyTo(recipe: String, consumer: Case => Unit): Unit
+
+  def several[Container](implicit
+      factory: Factory[Case, Container]
+  ): Trials[Container]
 }

--- a/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -1,5 +1,7 @@
 package com.sageserpent.americium
 
+import scala.collection.BuildFrom
+
 trait TrialsApi {
   def delay[Case](delayed: => Trials[Case]): Trials[Case]
 
@@ -30,4 +32,10 @@ trait TrialsApi {
   def doubles: Trials[Double]
 
   def booleans: Trials[Boolean]
+
+  def several[Container[_], ItemCase](
+      items: Trials[ItemCase]
+  )(implicit
+      bf: BuildFrom[List[ItemCase], ItemCase, Container[ItemCase]]
+  ): Trials[Container[ItemCase]]
 }

--- a/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -1,7 +1,5 @@
 package com.sageserpent.americium
 
-import scala.collection.Factory
-
 trait TrialsApi {
   def delay[Case](delayed: => Trials[Case]): Trials[Case]
 
@@ -32,10 +30,4 @@ trait TrialsApi {
   def doubles: Trials[Double]
 
   def booleans: Trials[Boolean]
-
-  def several[Container, ItemCase](
-      items: Trials[ItemCase]
-  )(implicit
-      factory: Factory[ItemCase, Container]
-  ): Trials[Container]
 }

--- a/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -1,6 +1,6 @@
 package com.sageserpent.americium
 
-import scala.collection.BuildFrom
+import scala.collection.Factory
 
 trait TrialsApi {
   def delay[Case](delayed: => Trials[Case]): Trials[Case]
@@ -33,9 +33,9 @@ trait TrialsApi {
 
   def booleans: Trials[Boolean]
 
-  def several[Container[_], ItemCase](
+  def several[Container, ItemCase](
       items: Trials[ItemCase]
   )(implicit
-      bf: BuildFrom[List[ItemCase], ItemCase, Container[ItemCase]]
-  ): Trials[Container[ItemCase]]
+      factory: Factory[ItemCase, Container]
+  ): Trials[Container]
 }

--- a/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
+++ b/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
@@ -102,18 +102,18 @@ object TrialsImplementation {
     )(implicit
         bf: BuildFrom[List[ItemCase], ItemCase, Container[ItemCase]]
     ): Trials[Container[ItemCase]] = {
+      val builder = bf.newBuilder(Nil)
 
-      def addItem(partialResult: List[ItemCase]): Trials[Container[ItemCase]] =
+      def addItem: Trials[Container[ItemCase]] =
         alternate(
-          only {
-            val builder = bf.newBuilder(Nil)
-            partialResult.foreach(builder += _)
-            builder.result()
-          },
-          items.flatMap(item => addItem(item :: partialResult))
+          only(builder.result()),
+          items.flatMap { item =>
+            builder += item
+            addItem
+          }
         )
 
-      addItem(Nil)
+      addItem
     }
   }
 

--- a/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
+++ b/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
@@ -29,7 +29,7 @@ import _root_.java.util.function.{
   Supplier,
   Function => JavaFunction
 }
-import scala.collection.{BuildFrom, mutable}
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
@@ -97,16 +97,16 @@ object TrialsImplementation {
   // as trait implementation, but that doesn't sit nicely with the
   // analogous Java interface `JavaTrialsAPi`, so let's go with this...
   trait Wart extends TrialsApi {
-    override def several[Container[_], ItemCase](
+    override def several[Container, ItemCase](
         items: Trials[ItemCase]
     )(implicit
-        bf: BuildFrom[List[ItemCase], ItemCase, Container[ItemCase]]
-    ): Trials[Container[ItemCase]] = {
+        factory: scala.collection.Factory[ItemCase, Container]
+    ): Trials[Container] = {
 
-      def addItem(partialResult: List[ItemCase]): Trials[Container[ItemCase]] =
+      def addItem(partialResult: List[ItemCase]): Trials[Container] =
         alternate(
           only {
-            val builder = bf.newBuilder(Nil)
+            val builder = factory.newBuilder
             partialResult.foreach(builder += _)
             builder.result()
           },

--- a/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
+++ b/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
@@ -146,6 +146,11 @@ class TrialsSpec
       .several[Set[_]]
       .withLimit(limit)
       .supplyTo(println)
+
+    api.integers
+      .several[Vector[_]]
+      .withLimit(limit)
+      .supplyTo(println)
   }
 
   "test driving the Java API" should "not produce smoke" in {

--- a/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
+++ b/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
@@ -39,33 +39,16 @@ object TrialsSpec {
   val limit: Int = 2000
 
   def integerVectorTrials: Trials[Vector[Int]] =
-    api.alternate(
-      api.only(Vector.empty),
-      api.integers.flatMap(head =>
-        integerVectorTrials.map(tail => head +: tail)
-      )
-    )
+    api.integers.several
 
   def doubleVectorTrials: Trials[Vector[Double]] =
-    api.alternate(
-      api.only(Vector.empty),
-      api.doubles.flatMap(head => doubleVectorTrials.map(tail => head +: tail))
-    )
+    api.doubles.several
 
   def longVectorTrials: Trials[Vector[Long]] =
-    api.alternate(
-      api.only(Vector.empty),
-      api.longs.flatMap(head => longVectorTrials.map(tail => head +: tail))
-    )
+    api.longs.several
 
   def listTrials: Trials[List[Int]] =
-    api.alternate(
-      for {
-        head <- api.integers
-        tail <- listTrials
-      } yield head :: tail,
-      api.only(Nil)
-    )
+    api.integers.several
 
   def binaryTreeTrials: Trials[BinaryTree] =
     api.alternate(

--- a/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
+++ b/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
@@ -143,7 +143,7 @@ class TrialsSpec
       .supplyTo(println)
 
     api
-      .several[List, Int](api.integers)
+      .several[Set[_], Int](api.integers)
       .withLimit(limit)
       .supplyTo(println)
   }
@@ -470,7 +470,7 @@ class TrialsSpec
 
         val sut: Trials[List[Any]] =
           api
-            .several(input match {
+            .several[List[_], Any](input match {
               case sequence: Seq[_] => api.choose(sequence)
               case factory: (Long => Any) =>
                 api.stream(factory)

--- a/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
+++ b/src/test/scala/com/sageserpent/americium/TrialsSpec.scala
@@ -141,6 +141,11 @@ class TrialsSpec
     api.booleans
       .withLimit(limit)
       .supplyTo(println)
+
+    api
+      .several[List, Int](api.integers)
+      .withLimit(limit)
+      .supplyTo(println)
   }
 
   "test driving the Java API" should "not produce smoke" in {
@@ -308,6 +313,7 @@ class TrialsSpec
         Seq(1 to 10, 20 to 30 map (_.toString)),
         Seq(1 to 10, Seq(true, false), 20 to 30),
         Seq(1, "3", 99),
+        Seq(1, "3", 2 to 4),
         Seq(1 to 10, Seq(12), -3 to -1),
         Seq(Seq(0), 1 to 10, 13, -3 to -1)
       )
@@ -341,6 +347,7 @@ class TrialsSpec
         Seq(1 to 10, 20 to 30 map (_.toString)),
         Seq(1 to 10, Seq(true, false), 20 to 30),
         Seq(1, "3", 99),
+        Seq(1, "3", 2 to 4),
         Seq(1 to 10, Seq(12), -3 to -1),
         Seq(Seq(0), 1 to 10, 13, -3 to -1),
         Seq((_: Long).toString),

--- a/src/test/scala/com/sageserpent/americium/java/TrialsApiTests.java
+++ b/src/test/scala/com/sageserpent/americium/java/TrialsApiTests.java
@@ -12,7 +12,7 @@ public class TrialsApiTests {
                 api.integers()
                         .flatMap(value -> chainedIntegers()
                                 .map(chain -> String.join(",", value.toString(), chain))),
-                api.only(""));
+                api.only("*** END ***"));
     }
 
     Trials<String> chainedBooleansAndIntegersInATree() {
@@ -22,6 +22,11 @@ public class TrialsApiTests {
                                 .flatMap(side -> chainedBooleansAndIntegersInATree()
                                         .map(right -> "(" + String.join(",", left, side.toString(), right) + ")"))),
                 api.integers().map(value -> value.toString()));
+    }
+
+    Trials<String> chainedIntegersUsingAnExplicitTerminationCase() {
+        return api.booleans().flatMap(terminate ->
+                terminate ? api.only("*** END ***") : api.integers().flatMap(value -> chainedIntegersUsingAnExplicitTerminationCase().map(simplerCase -> String.join(",", value.toString(), simplerCase))));
     }
 
     @Test
@@ -43,13 +48,21 @@ public class TrialsApiTests {
             System.out.println(number.doubleValue());
         });
 
-        final Trials<? extends Number> alternateTrailsFromArray = api.alternate(new Trials[]{integerTrials, doubleTrials, bigDecimalTrials});
+        final Trials<? extends Number> alternateTrialsFromArray = api.alternate(new Trials[]{integerTrials, doubleTrials, bigDecimalTrials});
 
-        alternateTrailsFromArray.withLimit(limit).supplyTo(number -> {
+        alternateTrialsFromArray.withLimit(limit).supplyTo(number -> {
             System.out.println(number.doubleValue());
         });
 
+        System.out.println("Chained integers...");
+
         chainedIntegers().withLimit(limit).supplyTo(System.out::println);
+
+        System.out.println("Chained integers using an explicit termination case...");
+
+        chainedIntegersUsingAnExplicitTerminationCase().withLimit(limit).supplyTo(System.out::println);
+
+        System.out.println("Chained integers and Booleans in a tree...");
 
         chainedBooleansAndIntegersInATree().withLimit(limit).supplyTo(System.out::println);
     }


### PR DESCRIPTION
Introducing a combinator to build a `Trials[Container[Case]]` from a simpler `Trials[Case]` - the type of `Container` can be anything supported by the Scala library `Factory` abstraction.

This adds method `several` to the Scala flavour of `Trials` - this yields cases that are collections whose elements would be yielded by the base trials instance. The collection cases include the empty case, and are potentially unbounded in size.

This is analogous to `Gen.listOf` in the Scalacheck library, only is expressed directly on the instance used as the base provider, rather than in a companion object or in `TrialsApi`; this permits simpler type inference and requires less code at the call sites.

An implicit is used to provide the `Factory` instance - rather like the `to` method provided on the standard Scala collections.