### PR TITLE
Add partitioning methods to TrialsApi

### DIFF
--- a/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
@@ -370,4 +370,30 @@ public interface TrialsApi {
     <Element> Trials<List<Element>> pickAlternatelyFrom(
             boolean shrinkToRoundRobin,
             Iterable<Element>... iterable);
+
+    /**
+     * Produce a trials instance that yields a list of pieces whose
+     * concatenation is {@code items}.
+     *
+     * @param items          The items to be split into pieces.
+     * @param numberOfPieces The number of pieces to split {@code items} into.
+     * @param <Element>      The type of the elements in {@code items}.
+     * @return A {@link Trials} instance that yields a list of pieces.
+     */
+    <Element> Trials<List<List<Element>>> splitIntoPieces(
+            List<Element> items,
+            int numberOfPieces);
+
+    /**
+     * Produce a trials instance that yields a list of non-empty pieces whose
+     * concatenation is {@code items}.
+     *
+     * @param items          The items to be split into pieces.
+     * @param numberOfPieces The number of pieces to split {@code items} into.
+     * @param <Element>      The type of the elements in {@code items}.
+     * @return A {@link Trials} instance that yields a list of non-empty pieces.
+     */
+    <Element> Trials<List<List<Element>>> splitIntoNonEmptyPieces(
+            List<Element> items,
+            int numberOfPieces);
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -373,4 +373,42 @@ trait TrialsApi {
       shrinkToRoundRobin: Boolean,
       iterables: Iterable[Element]*
   ): Trials[Vector[Element]]
+
+  /** Produce a trials instance that yields a sequence of pieces whose
+    * concatenation is {@code items} .
+    *
+    * @param items
+    *   The items to be split into pieces.
+    * @param numberOfPieces
+    *   The number of pieces to split {@code items} into.
+    * @tparam Element
+    *   The type of the elements in {@code items} .
+    * @tparam Container
+    *   The type of {@code items} and the pieces.
+    * @return
+    *   A [[Trials]] instance that yields a sequence of pieces.
+    */
+  def splitIntoPieces[Element, Container[X] <: Iterable[X]](
+      items: Container[Element],
+      numberOfPieces: Int
+  ): Trials[Seq[Container[Element]]]
+
+  /** Produce a trials instance that yields a sequence of non-empty pieces whose
+    * concatenation is {@code items} .
+    *
+    * @param items
+    *   The items to be split into pieces.
+    * @param numberOfPieces
+    *   The number of pieces to split {@code items} into.
+    * @tparam Element
+    *   The type of the elements in {@code items} .
+    * @tparam Container
+    *   The type of {@code items} and the pieces.
+    * @return
+    *   A [[Trials]] instance that yields a sequence of non-empty pieces.
+    */
+  def splitIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
+      items: Container[Element],
+      numberOfPieces: Int
+  ): Trials[Seq[Container[Element]]]
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
@@ -502,7 +502,7 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
       if (candidateLists.isEmpty) only(Vector.empty)
       else
         integers(0, candidateLists.size - 1).flatMap { chosenCandidateIndex =>
-          val (prefix, Vector(listToPickFrom, suffix*)) =
+          val (prefix, Vector(listToPickFrom, suffix @ _*)) =
             candidateLists.splitAt(chosenCandidateIndex): @unchecked
 
           val remainders = prefix ++ suffix
@@ -526,4 +526,72 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
 
     pickAnItem(iterables.map(LazyList.from(_)).toVector)
   }
+
+  override def splitIntoPieces[Element, Container[X] <: Iterable[X]](
+      items: Container[Element],
+      numberOfPieces: Int
+  ): Trials[Seq[Container[Element]]] = {
+    require(0 < numberOfPieces)
+
+    val numberOfItems = items.size
+
+    val partitionPointIndexVectors =
+      if (0 < numberOfItems)
+        integers(lowerBound = 0, upperBound = numberOfItems)
+          .lotsOfSize[Vector[Int]](numberOfPieces - 1)
+          .map(_.sorted)
+      else only(Vector.fill(numberOfPieces - 1)(0))
+
+    partitionPointIndexVectors.map { partitionPointIndices =>
+      val chunkSizes = (0 +: partitionPointIndices)
+        .zip(partitionPointIndices :+ numberOfItems)
+        .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
+          onePastPartitionEndIndex - partitionStartIndex
+        }
+
+      thingsInChunks(chunkSizes, items)
+    }
+  }
+
+  override def splitIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
+      items: Container[Element],
+      numberOfPieces: Int
+  ): Trials[Seq[Container[Element]]] = {
+    require(0 < numberOfPieces)
+
+    val numberOfItems = items.size
+
+    val chunkSizeVectors =
+      indexCombinations(
+        numberOfIndices = numberOfItems - 1,
+        combinationSize = numberOfPieces - 1
+      ).map(_.map(1 + _))
+        .map(partitionPointIndices =>
+          (0 +: partitionPointIndices)
+            .zip(partitionPointIndices :+ numberOfItems)
+            .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
+              onePastPartitionEndIndex - partitionStartIndex
+            }
+        )
+
+    chunkSizeVectors.map(chunkSizes => thingsInChunks(chunkSizes, items))
+  }
+
+  private def thingsInChunks[Element, Container[X] <: Iterable[X]](
+      chunkSizes: Seq[Int],
+      things: Container[Element]
+  ): Seq[Container[Element]] =
+    chunkSizes match {
+      case Seq(leadingChunkSize, chunkSizesTail @ _*) =>
+        val (leadingChunk, remainder) =
+          things.splitAt(leadingChunkSize): @unchecked
+
+        leadingChunk.asInstanceOf[Container[Element]] +: thingsInChunks(
+          chunkSizesTail,
+          remainder.asInstanceOf[Container[Element]]
+        )
+      case Nil =>
+        assume(things.isEmpty)
+        Seq.empty
+    }
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
@@ -388,4 +388,25 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
       .map(_.asJava)
       .javaTrials
   }
+
+  override def splitIntoPieces[Element](
+      items: JavaList[Element],
+      numberOfPieces: Int
+  ): JavaTrials[JavaList[JavaList[Element]]] =
+    scalaApi
+      .splitIntoPieces[Element, List](items.asScala.toList, numberOfPieces)
+      .map(_.map(_.asJava).asJava)
+      .javaTrials
+
+  override def splitIntoNonEmptyPieces[Element](
+      items: JavaList[Element],
+      numberOfPieces: Int
+  ): JavaTrials[JavaList[JavaList[Element]]] =
+    scalaApi
+      .splitIntoNonEmptyPieces[Element, List](
+        items.asScala.toList,
+        numberOfPieces
+      )
+      .map(_.map(_.asJava).asJava)
+      .javaTrials
 }

--- a/core-library/src/test/java/com/sageserpent/americium/java/SplitIntoPiecesJavaTest.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/SplitIntoPiecesJavaTest.java
@@ -2,37 +2,39 @@ package com.sageserpent.americium.java;
 
 import org.junit.jupiter.api.Test;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class SplitIntoPiecesJavaTest {
     private final TrialsApi api = Trials.api();
 
+    private final Trials<? extends List<Integer>> itemsTrials = api.integers().immutableLists();
+
     @Test
     void splitIntoPiecesShouldYieldPiecesThatConcatenateToTheOriginalItems() {
-        List<Integer> items = IntStream.range(0, 10).boxed().collect(Collectors.toList());
-        api.integers(1, 20).withLimit(10).supplyTo(numberOfPieces -> {
-            api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
-                assertThat(pieces.size(), is(numberOfPieces));
-                List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(Collectors.toList());
-                assertThat(concatenated, is(items));
+        itemsTrials.withLimit(50).supplyTo(items -> {
+            api.integers(1, Math.max(1, items.size())).withLimit(10).supplyTo(numberOfPieces -> {
+                api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
+                    assertThat(pieces.size(), is(numberOfPieces));
+                    List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(java.util.stream.Collectors.toList());
+                    assertThat(concatenated, is(items));
+                });
             });
         });
     }
 
     @Test
     void splitIntoNonEmptyPiecesShouldYieldNonEmptyPiecesThatConcatenateToTheOriginalItems() {
-        List<Integer> items = IntStream.range(0, 10).boxed().collect(Collectors.toList());
-        api.integers(1, items.size()).withLimit(10).supplyTo(numberOfPieces -> {
-            api.splitIntoNonEmptyPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
-                assertThat(pieces.size(), is(numberOfPieces));
-                List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(Collectors.toList());
-                assertThat(concatenated, is(items));
-                for (List<Integer> piece : pieces) {
-                    assertThat(piece, is(not(empty())));
-                }
+        itemsTrials.filter(items -> !items.isEmpty()).withLimit(50).supplyTo(items -> {
+            api.integers(1, items.size()).withLimit(10).supplyTo(numberOfPieces -> {
+                api.splitIntoNonEmptyPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
+                    assertThat(pieces.size(), is(numberOfPieces));
+                    List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(java.util.stream.Collectors.toList());
+                    assertThat(concatenated, is(items));
+                    for (List<Integer> piece : pieces) {
+                        assertThat(piece, is(not(empty())));
+                    }
+                });
             });
         });
     }

--- a/core-library/src/test/java/com/sageserpent/americium/java/SplitIntoPiecesJavaTest.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/SplitIntoPiecesJavaTest.java
@@ -1,0 +1,39 @@
+package com.sageserpent.americium.java;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class SplitIntoPiecesJavaTest {
+    private final TrialsApi api = Trials.api();
+
+    @Test
+    void splitIntoPiecesShouldYieldPiecesThatConcatenateToTheOriginalItems() {
+        List<Integer> items = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        api.integers(1, 20).withLimit(10).supplyTo(numberOfPieces -> {
+            api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
+                assertThat(pieces.size(), is(numberOfPieces));
+                List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(Collectors.toList());
+                assertThat(concatenated, is(items));
+            });
+        });
+    }
+
+    @Test
+    void splitIntoNonEmptyPiecesShouldYieldNonEmptyPiecesThatConcatenateToTheOriginalItems() {
+        List<Integer> items = IntStream.range(0, 10).boxed().collect(Collectors.toList());
+        api.integers(1, items.size()).withLimit(10).supplyTo(numberOfPieces -> {
+            api.splitIntoNonEmptyPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
+                assertThat(pieces.size(), is(numberOfPieces));
+                List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(Collectors.toList());
+                assertThat(concatenated, is(items));
+                for (List<Integer> piece : pieces) {
+                    assertThat(piece, is(not(empty())));
+                }
+            });
+        });
+    }
+}

--- a/core-library/src/test/java/com/sageserpent/americium/java/SplitIntoPiecesJavaTest.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/SplitIntoPiecesJavaTest.java
@@ -12,30 +12,42 @@ public class SplitIntoPiecesJavaTest {
 
     @Test
     void splitIntoPiecesShouldYieldPiecesThatConcatenateToTheOriginalItems() {
-        itemsTrials.withLimit(50).supplyTo(items -> {
-            api.integers(1, Math.max(1, items.size())).withLimit(10).supplyTo(numberOfPieces -> {
-                api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
-                    assertThat(pieces.size(), is(numberOfPieces));
-                    List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(java.util.stream.Collectors.toList());
-                    assertThat(concatenated, is(items));
-                });
-            });
+        itemsTrials.flatMap(items ->
+            api.integers(1, Math.max(1, items.size())).flatMap(numberOfPieces ->
+                api.splitIntoPieces(items, numberOfPieces).map(pieces ->
+                    new Object() {
+                        final List<Integer> itemsValue = items;
+                        final int numberOfPiecesValue = numberOfPieces;
+                        final List<List<Integer>> piecesValue = pieces;
+                    }
+                )
+            )
+        ).withLimit(100).supplyTo(testCase -> {
+            assertThat(testCase.piecesValue.size(), is(testCase.numberOfPiecesValue));
+            List<Integer> concatenated = testCase.piecesValue.stream().flatMap(List::stream).collect(java.util.stream.Collectors.toList());
+            assertThat(concatenated, is(testCase.itemsValue));
         });
     }
 
     @Test
     void splitIntoNonEmptyPiecesShouldYieldNonEmptyPiecesThatConcatenateToTheOriginalItems() {
-        itemsTrials.filter(items -> !items.isEmpty()).withLimit(50).supplyTo(items -> {
-            api.integers(1, items.size()).withLimit(10).supplyTo(numberOfPieces -> {
-                api.splitIntoNonEmptyPieces(items, numberOfPieces).withLimit(10).supplyTo(pieces -> {
-                    assertThat(pieces.size(), is(numberOfPieces));
-                    List<Integer> concatenated = pieces.stream().flatMap(List::stream).collect(java.util.stream.Collectors.toList());
-                    assertThat(concatenated, is(items));
-                    for (List<Integer> piece : pieces) {
-                        assertThat(piece, is(not(empty())));
+        itemsTrials.filter(items -> !items.isEmpty()).flatMap(items ->
+            api.integers(1, items.size()).flatMap(numberOfPieces ->
+                api.splitIntoNonEmptyPieces(items, numberOfPieces).map(pieces ->
+                    new Object() {
+                        final List<Integer> itemsValue = items;
+                        final int numberOfPiecesValue = numberOfPieces;
+                        final List<List<Integer>> piecesValue = pieces;
                     }
-                });
-            });
+                )
+            )
+        ).withLimit(100).supplyTo(testCase -> {
+            assertThat(testCase.piecesValue.size(), is(testCase.numberOfPiecesValue));
+            List<Integer> concatenated = testCase.piecesValue.stream().flatMap(List::stream).collect(java.util.stream.Collectors.toList());
+            assertThat(concatenated, is(testCase.itemsValue));
+            for (List<Integer> piece : testCase.piecesValue) {
+                assertThat(piece, is(not(empty())));
+            }
         });
     }
 }

--- a/core-library/src/test/scala/com/sageserpent/americium/SplitIntoPiecesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/SplitIntoPiecesTest.scala
@@ -1,0 +1,41 @@
+package com.sageserpent.americium
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
+  val api = Trials.api
+
+  "splitIntoPieces" should "yield pieces that concatenate to the original items" in {
+    val items = (1 to 10).toVector
+    api.integers(1, 20).withLimit(10).supplyTo { numberOfPieces =>
+      api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo { pieces =>
+        pieces.size should be(numberOfPieces)
+        pieces.flatten should be(items)
+      }
+    }
+  }
+
+  it should "preserve the container type of the pieces" in {
+    val vectorItems = Vector(1, 2, 3)
+    api.splitIntoPieces(vectorItems, 2).withLimit(1).supplyTo { pieces =>
+      pieces.head shouldBe a[Vector[_]]
+    }
+
+    val listItems = List(1, 2, 3)
+    api.splitIntoPieces(listItems, 2).withLimit(1).supplyTo { pieces =>
+      pieces.head shouldBe a[List[_]]
+    }
+  }
+
+  "splitIntoNonEmptyPieces" should "yield non-empty pieces that concatenate to the original items" in {
+    val items = (1 to 10).toVector
+    api.integers(1, items.size).withLimit(10).supplyTo { numberOfPieces =>
+      api.splitIntoNonEmptyPieces(items, numberOfPieces).withLimit(10).supplyTo { pieces =>
+        pieces.size should be(numberOfPieces)
+        pieces.flatten should be(items)
+        pieces.forall(_.nonEmpty) should be(true)
+      }
+    }
+  }
+}

--- a/core-library/src/test/scala/com/sageserpent/americium/SplitIntoPiecesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/SplitIntoPiecesTest.scala
@@ -10,17 +10,15 @@ class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
     api.integers.several[Vector[Int]]
 
   "splitIntoPieces" should "yield pieces that concatenate to the original items" in {
-    itemsTrials.withLimit(50).supplyTo { items =>
-      api
-        .integers(1, items.size max 1)
-        .withLimit(10)
-        .supplyTo { numberOfPieces =>
-          api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo {
-            pieces =>
-              pieces.size should be(numberOfPieces)
-              pieces.flatten should be(items)
-          }
-        }
+    val testCaseTrials = for {
+      items          <- itemsTrials
+      numberOfPieces <- api.integers(1, items.size max 1)
+      pieces         <- api.splitIntoPieces(items, numberOfPieces)
+    } yield (items, numberOfPieces, pieces)
+
+    testCaseTrials.withLimit(100).supplyTo { case (items, numberOfPieces, pieces) =>
+      pieces.size should be(numberOfPieces)
+      pieces.flatten should be(items)
     }
   }
 
@@ -37,17 +35,16 @@ class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
   }
 
   "splitIntoNonEmptyPieces" should "yield non-empty pieces that concatenate to the original items" in {
-    itemsTrials.filter(_.nonEmpty).withLimit(50).supplyTo { items =>
-      api.integers(1, items.size).withLimit(10).supplyTo { numberOfPieces =>
-        api
-          .splitIntoNonEmptyPieces(items, numberOfPieces)
-          .withLimit(10)
-          .supplyTo { pieces =>
-            pieces.size should be(numberOfPieces)
-            pieces.flatten should be(items)
-            pieces.forall(_.nonEmpty) should be(true)
-          }
-      }
+    val testCaseTrials = for {
+      items          <- itemsTrials.filter(_.nonEmpty)
+      numberOfPieces <- api.integers(1, items.size)
+      pieces         <- api.splitIntoNonEmptyPieces(items, numberOfPieces)
+    } yield (items, numberOfPieces, pieces)
+
+    testCaseTrials.withLimit(100).supplyTo { case (items, numberOfPieces, pieces) =>
+      pieces.size should be(numberOfPieces)
+      pieces.flatten should be(items)
+      pieces.forall(_.nonEmpty) should be(true)
     }
   }
 }

--- a/core-library/src/test/scala/com/sageserpent/americium/SplitIntoPiecesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/SplitIntoPiecesTest.scala
@@ -6,13 +6,21 @@ import org.scalatest.matchers.should.Matchers
 class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
   val api = Trials.api
 
+  private val itemsTrials: Trials[Vector[Int]] =
+    api.integers.several[Vector[Int]]
+
   "splitIntoPieces" should "yield pieces that concatenate to the original items" in {
-    val items = (1 to 10).toVector
-    api.integers(1, 20).withLimit(10).supplyTo { numberOfPieces =>
-      api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo { pieces =>
-        pieces.size should be(numberOfPieces)
-        pieces.flatten should be(items)
-      }
+    itemsTrials.withLimit(50).supplyTo { items =>
+      api
+        .integers(1, items.size max 1)
+        .withLimit(10)
+        .supplyTo { numberOfPieces =>
+          api.splitIntoPieces(items, numberOfPieces).withLimit(10).supplyTo {
+            pieces =>
+              pieces.size should be(numberOfPieces)
+              pieces.flatten should be(items)
+          }
+        }
     }
   }
 
@@ -29,12 +37,16 @@ class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
   }
 
   "splitIntoNonEmptyPieces" should "yield non-empty pieces that concatenate to the original items" in {
-    val items = (1 to 10).toVector
-    api.integers(1, items.size).withLimit(10).supplyTo { numberOfPieces =>
-      api.splitIntoNonEmptyPieces(items, numberOfPieces).withLimit(10).supplyTo { pieces =>
-        pieces.size should be(numberOfPieces)
-        pieces.flatten should be(items)
-        pieces.forall(_.nonEmpty) should be(true)
+    itemsTrials.filter(_.nonEmpty).withLimit(50).supplyTo { items =>
+      api.integers(1, items.size).withLimit(10).supplyTo { numberOfPieces =>
+        api
+          .splitIntoNonEmptyPieces(items, numberOfPieces)
+          .withLimit(10)
+          .supplyTo { pieces =>
+            pieces.size should be(numberOfPieces)
+            pieces.flatten should be(items)
+            pieces.forall(_.nonEmpty) should be(true)
+          }
       }
     }
   }


### PR DESCRIPTION
I have ported the `splitIntoPieces` and `splitIntoNonEmptyPieces` methods from the kineticMerge repository into the Americium `TrialsApi`. 

The Scala implementation is generalized to support any collection type that extends `Iterable` and provides `splitAt`, and it ensures that the pieces preserve the original container type (e.g., splitting a `Vector` results in a sequence of `Vector`s).

The Java implementation provides a clean adapter for `java.util.List`.

I have also added comprehensive unit tests for both Scala and Java to verify correctness and container type preservation.

Additionally, I fixed a minor Scala 3 syntax issue in `TrialsApiImplementation.scala` that I encountered during the implementation.

---
*PR created automatically by Jules for task [8202498932849261915](https://jules.google.com/task/8202498932849261915) started by @sageserpent-open*