### PR TITLE
Add `shuffles` API and rename `splitInto` methods

### DIFF
--- a/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
@@ -382,7 +382,7 @@ public interface TrialsApi {
      * @apiNote The resulting pieces may be empty, and if more pieces are
      * requested than there are items then some *must* be empty.
      */
-    <Element> Trials<List<List<Element>>> splitIntoPieces(
+    <Element> Trials<List<List<Element>>> splitsIntoPieces(
             List<Element> items,
             int numberOfPieces);
 
@@ -395,7 +395,7 @@ public interface TrialsApi {
      * @param <Element>      The type of the elements in {@code items}.
      * @return A {@link Trials} instance that yields a list of non-empty pieces.
      */
-    <Element> Trials<List<List<Element>>> splitIntoNonEmptyPieces(
+    <Element> Trials<List<List<Element>>> splitsIntoNonEmptyPieces(
             List<Element> items,
             int numberOfPieces);
 
@@ -407,6 +407,15 @@ public interface TrialsApi {
      * @param <Element>      The type of the elements in {@code items}.
      * @return A {@link Trials} instance that yields a list of non-empty pieces.
      */
-    <Element> Trials<List<List<Element>>> splitIntoNonEmptyPieces(
+    <Element> Trials<List<List<Element>>> splitsIntoNonEmptyPieces(
             List<Element> items);
+
+    /**
+     * Produce a trials instance that yields shuffles of {@code items}.
+     *
+     * @param items     The items to be shuffled.
+     * @param <Element> The type of the elements in {@code items}.
+     * @return A {@link Trials} instance that yields shuffles.
+     */
+    <Element> Trials<List<Element>> shuffles(List<Element> items);
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -394,8 +394,6 @@ trait TrialsApi {
   def splitsIntoPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
-  )(implicit
-      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields a sequence of non-empty pieces whose
@@ -415,8 +413,6 @@ trait TrialsApi {
   def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
-  )(implicit
-      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields a sequence of non-empty pieces whose
@@ -433,8 +429,6 @@ trait TrialsApi {
     */
   def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element]
-  )(implicit
-      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields shuffles of {@code items}.

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -394,6 +394,8 @@ trait TrialsApi {
   def splitsIntoPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields a sequence of non-empty pieces whose
@@ -413,6 +415,8 @@ trait TrialsApi {
   def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields a sequence of non-empty pieces whose
@@ -429,6 +433,8 @@ trait TrialsApi {
     */
   def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element]
+  )(implicit
+      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields shuffles of {@code items}.

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -391,9 +391,11 @@ trait TrialsApi {
     *   The resulting pieces may be empty, and if more pieces are requested than
     *   there are items then some *must* be empty.
     */
-  def splitIntoPieces[Element, Container[X] <: Iterable[X]](
+  def splitsIntoPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields a sequence of non-empty pieces whose
@@ -410,9 +412,11 @@ trait TrialsApi {
     * @return
     *   A [[Trials]] instance that yields a sequence of non-empty pieces.
     */
-  def splitIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
+  def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
 
   /** Produce a trials instance that yields a sequence of non-empty pieces whose
@@ -427,7 +431,26 @@ trait TrialsApi {
     * @return
     *   A [[Trials]] instance that yields a sequence of non-empty pieces.
     */
-  def splitIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
+  def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element]
+  )(implicit
+      factory: Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]]
+
+  /** Produce a trials instance that yields shuffles of {@code items}.
+    *
+    * @param items
+    *   The items to be shuffled.
+    * @tparam Element
+    *   The type of the elements in {@code items}.
+    * @tparam Container
+    *   The type of {@code items} and the shuffles.
+    * @return
+    *   A [[Trials]] instance that yields shuffles.
+    */
+  def shuffles[Element, Container[X] <: Iterable[X]](
+      items: Container[Element]
+  )(implicit
+      factory: Factory[Element, Container[Element]]
+  ): Trials[Container[Element]]
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
@@ -527,9 +527,11 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   def resetComplexity(complexity: Int): TrialsImplementation[Unit] =
     new TrialsImplementation(ResetComplexity(complexity))
 
-  override def splitIntoPieces[Element, Container[X] <: Iterable[X]](
+  override def splitsIntoPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = {
     require(0 < numberOfPieces)
 
@@ -553,9 +555,11 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     }
   }
 
-  override def splitIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
+  override def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = {
     require(0 < numberOfPieces)
 
@@ -579,11 +583,22 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     chunkSizeVectors.map(chunkSizes => thingsInChunks(chunkSizes, items))
   }
 
-  override def splitIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
+  override def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element]
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = if (items.nonEmpty)
-    integers(1, items.size).flatMap(splitIntoNonEmptyPieces(items, _))
+    integers(1, items.size).flatMap(splitsIntoNonEmptyPieces(items, _))
   else only(Seq.empty)
+
+  override def shuffles[Element, Container[X] <: Iterable[X]](
+      items: Container[Element]
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
+  ): Trials[Container[Element]] = {
+    val indexedItems = items.toIndexedSeq
+    indexPermutations(items.size).map(_.map(indexedItems.apply).to(factory))
+  }
 
   private def thingsInChunks[Element, Container[X] <: Iterable[X]](
       chunkSizes: Seq[Int],

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
@@ -161,8 +161,34 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     override def maximallyShrunkInput: BigInt = shrinkageTarget
   })
 
+  def stream[Case](
+      caseFactory: CaseFactory[Case]
+  ): TrialsImplementation[Case] = new TrialsImplementation(
+    Factory(new CaseFactory[Case] {
+      require(lowerBoundInput <= maximallyShrunkInput)
+      require(maximallyShrunkInput <= upperBoundInput)
+
+      override def apply(input: BigInt): Case = {
+        require(lowerBoundInput <= input)
+        require(upperBoundInput >= input)
+        caseFactory(input)
+      }
+      override def lowerBoundInput: BigInt      = caseFactory.lowerBoundInput
+      override def upperBoundInput: BigInt      = caseFactory.upperBoundInput
+      override def maximallyShrunkInput: BigInt =
+        caseFactory.maximallyShrunkInput
+    })
+  )
+
   override def doubles: TrialsImplementation[Double] =
     doubles(Double.MinValue, Double.MaxValue, 0.0)
+
+  override def doubles(
+      lowerBound: Double,
+      upperBound: Double,
+      shrinkageTarget: Double
+  ): TrialsImplementation[Double] =
+    bigDecimals(lowerBound, upperBound, shrinkageTarget).map(_.toDouble)
 
   override def booleans: TrialsImplementation[Boolean] =
     choose(true, false)
@@ -187,12 +213,17 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     else 0.0
   )
 
-  override def doubles(
-      lowerBound: Double,
-      upperBound: Double,
-      shrinkageTarget: Double
-  ): TrialsImplementation[Double] =
-    bigDecimals(lowerBound, upperBound, shrinkageTarget).map(_.toDouble)
+  override def bigDecimals(
+      lowerBound: BigDecimal,
+      upperBound: BigDecimal
+  ): TrialsImplementation[BigDecimal] = bigDecimals(
+    lowerBound,
+    upperBound,
+    if (0.0 > upperBound)
+      upperBound
+    else if (0.0 < lowerBound) lowerBound
+    else 0.0
+  )
 
   override def bigDecimals(
       lowerBound: BigDecimal,
@@ -282,22 +313,17 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     else only(shrinkageTarget)
   }
 
-  override def bigDecimals(
-      lowerBound: BigDecimal,
-      upperBound: BigDecimal
-  ): TrialsImplementation[BigDecimal] = bigDecimals(
-    lowerBound,
-    upperBound,
-    if (0.0 > upperBound)
-      upperBound
-    else if (0.0 < lowerBound) lowerBound
-    else 0.0
-  )
-
   override def characters(
       lowerBound: Char,
       upperBound: Char
   ): TrialsImplementation[Char] = choose(lowerBound to upperBound)
+
+  override def choose[Case](
+      choices: Iterable[Case]
+  ): TrialsImplementation[Case] =
+    new TrialsImplementation(
+      Choice(SortedMap.from(LazyList.from(1).zip(choices)))
+    )
 
   override def characters(
       lowerBound: Char,
@@ -358,25 +384,6 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
       override def maximallyShrunkInput: BigInt = shrinkageTarget
     })
 
-  def stream[Case](
-      caseFactory: CaseFactory[Case]
-  ): TrialsImplementation[Case] = new TrialsImplementation(
-    Factory(new CaseFactory[Case] {
-      require(lowerBoundInput <= maximallyShrunkInput)
-      require(maximallyShrunkInput <= upperBoundInput)
-
-      override def apply(input: BigInt): Case = {
-        require(lowerBoundInput <= input)
-        require(upperBoundInput >= input)
-        caseFactory(input)
-      }
-      override def lowerBoundInput: BigInt      = caseFactory.lowerBoundInput
-      override def upperBoundInput: BigInt      = caseFactory.upperBoundInput
-      override def maximallyShrunkInput: BigInt =
-        caseFactory.maximallyShrunkInput
-    })
-  )
-
   override def instants(
       lowerBound: Instant,
       upperBound: Instant,
@@ -394,12 +401,50 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   override def characters: TrialsImplementation[Char] =
     choose(Char.MinValue to Char.MaxValue)
 
-  override def choose[Case](
-      choices: Iterable[Case]
-  ): TrialsImplementation[Case] =
-    new TrialsImplementation(
-      Choice(SortedMap.from(LazyList.from(1).zip(choices)))
+  override def indexPermutations(
+      numberOfIndices: Int
+  ): TrialsImplementation[Vector[Int]] =
+    indexPermutations(numberOfIndices, numberOfIndices)
+
+  override def indexPermutations(
+      numberOfIndices: Int,
+      permutationSize: Int
+  ): TrialsImplementation[Vector[Int]] = {
+    require(0 <= numberOfIndices)
+    require(0 to numberOfIndices contains permutationSize)
+
+    def indexPermutations(
+        cumulativePermutationSize: Int,
+        previouslyChosenItemsAsBinaryTree: RangeOfSlots,
+        partialResult: TrialsImplementation[Vector[Int]]
+    ): TrialsImplementation[Vector[Int]] = if (
+      permutationSize == cumulativePermutationSize
+    ) partialResult
+    else {
+      val exclusiveLimitOnVacantSlotIndex =
+        numberOfIndices - cumulativePermutationSize
+
+      integers(0, exclusiveLimitOnVacantSlotIndex - 1).flatMap(
+        vacantSlotIndex => {
+          val (filledSlot, chosenItemsAsBinaryTree) =
+            previouslyChosenItemsAsBinaryTree
+              .fillVacantSlotAtIndex(vacantSlotIndex)
+
+          indexPermutations(
+            1 + cumulativePermutationSize,
+            chosenItemsAsBinaryTree,
+            partialResult.map(_ :+ filledSlot)
+          )
+        }
+      )
+    }
+
+    indexPermutations(
+      0,
+      RangeOfSlots.allSlotsAreVacant(numberOfIndices),
+      only(Vector.empty)
     )
+  }
 
   override def indexCombinations(
       numberOfIndices: Int,
@@ -485,24 +530,36 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   override def splitsIntoPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = {
     require(0 < numberOfPieces)
 
     val numberOfItems = items.size
 
-    val partitionPointIndices =
+    val partitionPointIndexVectors =
       if (0 < numberOfItems)
         integers(lowerBound = 0, upperBound = numberOfItems)
           .lotsOfSize[Vector[Int]](numberOfPieces - 1)
           .map(_.sorted)
       else only(Vector.fill(numberOfPieces - 1)(0))
 
-    applyPartitions(items, partitionPointIndices)
+    partitionPointIndexVectors.map { partitionPointIndices =>
+      val chunkSizes = (0 +: partitionPointIndices)
+        .zip(partitionPointIndices :+ numberOfItems)
+        .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
+          onePastPartitionEndIndex - partitionStartIndex
+        }
+
+      thingsInChunks(chunkSizes, items)
+    }
   }
 
   override def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = {
     require(0 < numberOfPieces)
 
@@ -510,16 +567,26 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
 
     require(numberOfPieces <= numberOfItems)
 
-    val partitionPointIndices = indexCombinations(
-      numberOfIndices = numberOfItems - 1,
-      combinationSize = numberOfPieces - 1
-    ).map(_.map(1 + _))
+    val chunkSizeVectors =
+      indexCombinations(
+        numberOfIndices = numberOfItems - 1,
+        combinationSize = numberOfPieces - 1
+      ).map(_.map(1 + _))
+        .map(partitionPointIndices =>
+          (0 +: partitionPointIndices)
+            .zip(partitionPointIndices :+ numberOfItems)
+            .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
+              onePastPartitionEndIndex - partitionStartIndex
+            }
+        )
 
-    applyPartitions(items, partitionPointIndices)
+    chunkSizeVectors.map(chunkSizes => thingsInChunks(chunkSizes, items))
   }
 
   override def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element]
+  )(implicit
+      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = if (items.nonEmpty)
     integers(1, items.size).flatMap(splitsIntoNonEmptyPieces(items, _))
   else only(Seq.empty)
@@ -531,66 +598,6 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   ): Trials[Container[Element]] = {
     val indexedItems = items.toIndexedSeq
     indexPermutations(items.size).map(_.map(indexedItems.apply).to(factory))
-  }
-
-  override def indexPermutations(
-      numberOfIndices: Int
-  ): TrialsImplementation[Vector[Int]] =
-    indexPermutations(numberOfIndices, numberOfIndices)
-
-  override def indexPermutations(
-      numberOfIndices: Int,
-      permutationSize: Int
-  ): TrialsImplementation[Vector[Int]] = {
-    require(0 <= numberOfIndices)
-    require(0 to numberOfIndices contains permutationSize)
-
-    def indexPermutations(
-        cumulativePermutationSize: Int,
-        previouslyChosenItemsAsBinaryTree: RangeOfSlots,
-        partialResult: TrialsImplementation[Vector[Int]]
-    ): TrialsImplementation[Vector[Int]] = if (
-      permutationSize == cumulativePermutationSize
-    ) partialResult
-    else {
-      val exclusiveLimitOnVacantSlotIndex =
-        numberOfIndices - cumulativePermutationSize
-
-      integers(0, exclusiveLimitOnVacantSlotIndex - 1).flatMap(
-        vacantSlotIndex => {
-          val (filledSlot, chosenItemsAsBinaryTree) =
-            previouslyChosenItemsAsBinaryTree
-              .fillVacantSlotAtIndex(vacantSlotIndex)
-
-          indexPermutations(
-            1 + cumulativePermutationSize,
-            chosenItemsAsBinaryTree,
-            partialResult.map(_ :+ filledSlot)
-          )
-        }
-      )
-    }
-
-    indexPermutations(
-      0,
-      RangeOfSlots.allSlotsAreVacant(numberOfIndices),
-      only(Vector.empty)
-    )
-  }
-
-  private def applyPartitions[Container[X] <: Iterable[X], Element](
-      items: Container[Element],
-      partitionPointIndices: Trials[Vector[Int]]
-  ): Trials[LazyList[Container[Element]]] = {
-    partitionPointIndices.map { partitionPointIndices =>
-      val chunkSizes = (0 +: partitionPointIndices)
-        .zip(partitionPointIndices :+ items.size)
-        .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
-          onePastPartitionEndIndex - partitionStartIndex
-        }
-
-      thingsInChunks(chunkSizes, items)
-    }
   }
 
   private def thingsInChunks[Element, Container[X] <: Iterable[X]](

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
@@ -161,34 +161,8 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     override def maximallyShrunkInput: BigInt = shrinkageTarget
   })
 
-  def stream[Case](
-      caseFactory: CaseFactory[Case]
-  ): TrialsImplementation[Case] = new TrialsImplementation(
-    Factory(new CaseFactory[Case] {
-      require(lowerBoundInput <= maximallyShrunkInput)
-      require(maximallyShrunkInput <= upperBoundInput)
-
-      override def apply(input: BigInt): Case = {
-        require(lowerBoundInput <= input)
-        require(upperBoundInput >= input)
-        caseFactory(input)
-      }
-      override def lowerBoundInput: BigInt      = caseFactory.lowerBoundInput
-      override def upperBoundInput: BigInt      = caseFactory.upperBoundInput
-      override def maximallyShrunkInput: BigInt =
-        caseFactory.maximallyShrunkInput
-    })
-  )
-
   override def doubles: TrialsImplementation[Double] =
     doubles(Double.MinValue, Double.MaxValue, 0.0)
-
-  override def doubles(
-      lowerBound: Double,
-      upperBound: Double,
-      shrinkageTarget: Double
-  ): TrialsImplementation[Double] =
-    bigDecimals(lowerBound, upperBound, shrinkageTarget).map(_.toDouble)
 
   override def booleans: TrialsImplementation[Boolean] =
     choose(true, false)
@@ -213,17 +187,12 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     else 0.0
   )
 
-  override def bigDecimals(
-      lowerBound: BigDecimal,
-      upperBound: BigDecimal
-  ): TrialsImplementation[BigDecimal] = bigDecimals(
-    lowerBound,
-    upperBound,
-    if (0.0 > upperBound)
-      upperBound
-    else if (0.0 < lowerBound) lowerBound
-    else 0.0
-  )
+  override def doubles(
+      lowerBound: Double,
+      upperBound: Double,
+      shrinkageTarget: Double
+  ): TrialsImplementation[Double] =
+    bigDecimals(lowerBound, upperBound, shrinkageTarget).map(_.toDouble)
 
   override def bigDecimals(
       lowerBound: BigDecimal,
@@ -313,17 +282,22 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     else only(shrinkageTarget)
   }
 
+  override def bigDecimals(
+      lowerBound: BigDecimal,
+      upperBound: BigDecimal
+  ): TrialsImplementation[BigDecimal] = bigDecimals(
+    lowerBound,
+    upperBound,
+    if (0.0 > upperBound)
+      upperBound
+    else if (0.0 < lowerBound) lowerBound
+    else 0.0
+  )
+
   override def characters(
       lowerBound: Char,
       upperBound: Char
   ): TrialsImplementation[Char] = choose(lowerBound to upperBound)
-
-  override def choose[Case](
-      choices: Iterable[Case]
-  ): TrialsImplementation[Case] =
-    new TrialsImplementation(
-      Choice(SortedMap.from(LazyList.from(1).zip(choices)))
-    )
 
   override def characters(
       lowerBound: Char,
@@ -384,6 +358,25 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
       override def maximallyShrunkInput: BigInt = shrinkageTarget
     })
 
+  def stream[Case](
+      caseFactory: CaseFactory[Case]
+  ): TrialsImplementation[Case] = new TrialsImplementation(
+    Factory(new CaseFactory[Case] {
+      require(lowerBoundInput <= maximallyShrunkInput)
+      require(maximallyShrunkInput <= upperBoundInput)
+
+      override def apply(input: BigInt): Case = {
+        require(lowerBoundInput <= input)
+        require(upperBoundInput >= input)
+        caseFactory(input)
+      }
+      override def lowerBoundInput: BigInt      = caseFactory.lowerBoundInput
+      override def upperBoundInput: BigInt      = caseFactory.upperBoundInput
+      override def maximallyShrunkInput: BigInt =
+        caseFactory.maximallyShrunkInput
+    })
+  )
+
   override def instants(
       lowerBound: Instant,
       upperBound: Instant,
@@ -401,50 +394,12 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   override def characters: TrialsImplementation[Char] =
     choose(Char.MinValue to Char.MaxValue)
 
-  override def indexPermutations(
-      numberOfIndices: Int
-  ): TrialsImplementation[Vector[Int]] =
-    indexPermutations(numberOfIndices, numberOfIndices)
-
-  override def indexPermutations(
-      numberOfIndices: Int,
-      permutationSize: Int
-  ): TrialsImplementation[Vector[Int]] = {
-    require(0 <= numberOfIndices)
-    require(0 to numberOfIndices contains permutationSize)
-
-    def indexPermutations(
-        cumulativePermutationSize: Int,
-        previouslyChosenItemsAsBinaryTree: RangeOfSlots,
-        partialResult: TrialsImplementation[Vector[Int]]
-    ): TrialsImplementation[Vector[Int]] = if (
-      permutationSize == cumulativePermutationSize
-    ) partialResult
-    else {
-      val exclusiveLimitOnVacantSlotIndex =
-        numberOfIndices - cumulativePermutationSize
-
-      integers(0, exclusiveLimitOnVacantSlotIndex - 1).flatMap(
-        vacantSlotIndex => {
-          val (filledSlot, chosenItemsAsBinaryTree) =
-            previouslyChosenItemsAsBinaryTree
-              .fillVacantSlotAtIndex(vacantSlotIndex)
-
-          indexPermutations(
-            1 + cumulativePermutationSize,
-            chosenItemsAsBinaryTree,
-            partialResult.map(_ :+ filledSlot)
-          )
-        }
-      )
-    }
-
-    indexPermutations(
-      0,
-      RangeOfSlots.allSlotsAreVacant(numberOfIndices),
-      only(Vector.empty)
+  override def choose[Case](
+      choices: Iterable[Case]
+  ): TrialsImplementation[Case] =
+    new TrialsImplementation(
+      Choice(SortedMap.from(LazyList.from(1).zip(choices)))
     )
-  }
 
   override def indexCombinations(
       numberOfIndices: Int,
@@ -530,36 +485,24 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   override def splitsIntoPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
-  )(implicit
-      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = {
     require(0 < numberOfPieces)
 
     val numberOfItems = items.size
 
-    val partitionPointIndexVectors =
+    val partitionPointIndices =
       if (0 < numberOfItems)
         integers(lowerBound = 0, upperBound = numberOfItems)
           .lotsOfSize[Vector[Int]](numberOfPieces - 1)
           .map(_.sorted)
       else only(Vector.fill(numberOfPieces - 1)(0))
 
-    partitionPointIndexVectors.map { partitionPointIndices =>
-      val chunkSizes = (0 +: partitionPointIndices)
-        .zip(partitionPointIndices :+ numberOfItems)
-        .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
-          onePastPartitionEndIndex - partitionStartIndex
-        }
-
-      thingsInChunks(chunkSizes, items)
-    }
+    applyPartitions(items, partitionPointIndices)
   }
 
   override def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element],
       numberOfPieces: Int
-  )(implicit
-      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = {
     require(0 < numberOfPieces)
 
@@ -567,26 +510,16 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
 
     require(numberOfPieces <= numberOfItems)
 
-    val chunkSizeVectors =
-      indexCombinations(
-        numberOfIndices = numberOfItems - 1,
-        combinationSize = numberOfPieces - 1
-      ).map(_.map(1 + _))
-        .map(partitionPointIndices =>
-          (0 +: partitionPointIndices)
-            .zip(partitionPointIndices :+ numberOfItems)
-            .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
-              onePastPartitionEndIndex - partitionStartIndex
-            }
-        )
+    val partitionPointIndices = indexCombinations(
+      numberOfIndices = numberOfItems - 1,
+      combinationSize = numberOfPieces - 1
+    ).map(_.map(1 + _))
 
-    chunkSizeVectors.map(chunkSizes => thingsInChunks(chunkSizes, items))
+    applyPartitions(items, partitionPointIndices)
   }
 
   override def splitsIntoNonEmptyPieces[Element, Container[X] <: Iterable[X]](
       items: Container[Element]
-  )(implicit
-      factory: collection.Factory[Element, Container[Element]]
   ): Trials[Seq[Container[Element]]] = if (items.nonEmpty)
     integers(1, items.size).flatMap(splitsIntoNonEmptyPieces(items, _))
   else only(Seq.empty)
@@ -598,6 +531,66 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
   ): Trials[Container[Element]] = {
     val indexedItems = items.toIndexedSeq
     indexPermutations(items.size).map(_.map(indexedItems.apply).to(factory))
+  }
+
+  override def indexPermutations(
+      numberOfIndices: Int
+  ): TrialsImplementation[Vector[Int]] =
+    indexPermutations(numberOfIndices, numberOfIndices)
+
+  override def indexPermutations(
+      numberOfIndices: Int,
+      permutationSize: Int
+  ): TrialsImplementation[Vector[Int]] = {
+    require(0 <= numberOfIndices)
+    require(0 to numberOfIndices contains permutationSize)
+
+    def indexPermutations(
+        cumulativePermutationSize: Int,
+        previouslyChosenItemsAsBinaryTree: RangeOfSlots,
+        partialResult: TrialsImplementation[Vector[Int]]
+    ): TrialsImplementation[Vector[Int]] = if (
+      permutationSize == cumulativePermutationSize
+    ) partialResult
+    else {
+      val exclusiveLimitOnVacantSlotIndex =
+        numberOfIndices - cumulativePermutationSize
+
+      integers(0, exclusiveLimitOnVacantSlotIndex - 1).flatMap(
+        vacantSlotIndex => {
+          val (filledSlot, chosenItemsAsBinaryTree) =
+            previouslyChosenItemsAsBinaryTree
+              .fillVacantSlotAtIndex(vacantSlotIndex)
+
+          indexPermutations(
+            1 + cumulativePermutationSize,
+            chosenItemsAsBinaryTree,
+            partialResult.map(_ :+ filledSlot)
+          )
+        }
+      )
+    }
+
+    indexPermutations(
+      0,
+      RangeOfSlots.allSlotsAreVacant(numberOfIndices),
+      only(Vector.empty)
+    )
+  }
+
+  private def applyPartitions[Container[X] <: Iterable[X], Element](
+      items: Container[Element],
+      partitionPointIndices: Trials[Vector[Int]]
+  ): Trials[LazyList[Container[Element]]] = {
+    partitionPointIndices.map { partitionPointIndices =>
+      val chunkSizes = (0 +: partitionPointIndices)
+        .zip(partitionPointIndices :+ items.size)
+        .map { case (partitionStartIndex, onePastPartitionEndIndex) =>
+          onePastPartitionEndIndex - partitionStartIndex
+        }
+
+      thingsInChunks(chunkSizes, items)
+    }
   }
 
   private def thingsInChunks[Element, Container[X] <: Iterable[X]](

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
@@ -389,31 +389,36 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
       .javaTrials
   }
 
-  override def splitIntoPieces[Element](
+  override def splitsIntoPieces[Element](
       items: JavaList[Element],
       numberOfPieces: Int
   ): JavaTrials[JavaList[JavaList[Element]]] =
     scalaApi
-      .splitIntoPieces[Element, List](items.asScala.toList, numberOfPieces)
+      .splitsIntoPieces[Element, List](items.asScala.toList, numberOfPieces)
       .map(_.map(_.asJava).asJava)
       .javaTrials
 
-  override def splitIntoNonEmptyPieces[Element](
+  override def splitsIntoNonEmptyPieces[Element](
       items: JavaList[Element],
       numberOfPieces: Int
   ): JavaTrials[JavaList[JavaList[Element]]] =
     scalaApi
-      .splitIntoNonEmptyPieces[Element, List](
+      .splitsIntoNonEmptyPieces[Element, List](
         items.asScala.toList,
         numberOfPieces
       )
       .map(_.map(_.asJava).asJava)
       .javaTrials
 
-  override def splitIntoNonEmptyPieces[Element](
+  override def splitsIntoNonEmptyPieces[Element](
       items: JavaList[Element]
   ): JavaTrials[JavaList[JavaList[Element]]] = scalaApi
-    .splitIntoNonEmptyPieces[Element, List](items.asScala.toList)
+    .splitsIntoNonEmptyPieces[Element, List](items.asScala.toList)
     .map(_.map(_.asJava).asJava)
     .javaTrials
+
+  override def shuffles[Element](
+      items: JavaList[Element]
+  ): JavaTrials[JavaList[Element]] =
+    scalaApi.shuffles[Element, List](items.asScala.toList).map(_.asJava).javaTrials
 }

--- a/core-library/src/test/java/com/sageserpent/americium/java/ShufflesJavaTest.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/ShufflesJavaTest.java
@@ -1,0 +1,41 @@
+package com.sageserpent.americium.java;
+
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ShufflesJavaTest {
+    private final TrialsApi api = Trials.api();
+
+    @Test
+    void shufflesShouldYieldAPermutationOfTheOriginalItems() {
+        List<Integer> items = Arrays.asList(1, 2, 3, 4, 5);
+        api.shuffles(items).withLimit(10).supplyTo(shuffled -> {
+            assertThat(shuffled, containsInAnyOrder(items.toArray()));
+            assertThat(shuffled, hasSize(items.size()));
+        });
+    }
+
+    @Test
+    void shufflesShouldEventuallyYieldAllPossibleShuffles() {
+        List<Integer> items = Arrays.asList(1, 2, 3);
+        int expectedNumberOfShuffles = 6; // 3!
+        Set<List<Integer>> shuffles = StreamSupport.stream(((Iterable<List<Integer>>) () -> api.shuffles(items).withLimit(100).asIterator()).spliterator(), false)
+                .collect(Collectors.toSet());
+        assertThat(shuffles, hasSize(expectedNumberOfShuffles));
+    }
+
+    @Test
+    void shufflesShouldHandleEmptyCollections() {
+        List<Integer> items = Arrays.asList();
+        api.shuffles(items).withLimit(1).supplyTo(shuffled -> {
+            assertThat(shuffled, is(empty()));
+        });
+    }
+}

--- a/core-library/src/test/java/com/sageserpent/americium/java/SplitsIntoPiecesJavaTest.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/SplitsIntoPiecesJavaTest.java
@@ -5,16 +5,16 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-public class SplitIntoPiecesJavaTest {
+public class SplitsIntoPiecesJavaTest {
     private final TrialsApi api = Trials.api();
 
     private final Trials<? extends List<Integer>> itemsTrials = api.integers().immutableLists();
 
     @Test
-    void splitIntoPiecesShouldYieldPiecesThatConcatenateToTheOriginalItems() {
+    void splitsIntoPiecesShouldYieldPiecesThatConcatenateToTheOriginalItems() {
         itemsTrials.flatMap(items ->
             api.integers(1, Math.max(1, items.size())).flatMap(numberOfPieces ->
-                api.splitIntoPieces(items, numberOfPieces).map(pieces ->
+                api.splitsIntoPieces(items, numberOfPieces).map(pieces ->
                     new Object() {
                         final List<Integer> itemsValue = items;
                         final int numberOfPiecesValue = numberOfPieces;
@@ -30,10 +30,10 @@ public class SplitIntoPiecesJavaTest {
     }
 
     @Test
-    void splitIntoNonEmptyPiecesShouldYieldNonEmptyPiecesThatConcatenateToTheOriginalItems() {
+    void splitsIntoNonEmptyPiecesShouldYieldNonEmptyPiecesThatConcatenateToTheOriginalItems() {
         itemsTrials.filter(items -> !items.isEmpty()).flatMap(items ->
             api.integers(1, items.size()).flatMap(numberOfPieces ->
-                api.splitIntoNonEmptyPieces(items, numberOfPieces).map(pieces ->
+                api.splitsIntoNonEmptyPieces(items, numberOfPieces).map(pieces ->
                     new Object() {
                         final List<Integer> itemsValue = items;
                         final int numberOfPiecesValue = numberOfPieces;

--- a/core-library/src/test/scala/com/sageserpent/americium/ShufflesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/ShufflesTest.scala
@@ -1,0 +1,47 @@
+package com.sageserpent.americium
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ShufflesTest extends AnyFlatSpec with Matchers {
+  val api = Trials.api
+
+  private val itemsTrials: Trials[Vector[Int]] =
+    api.integers.several[Vector[Int]]
+
+  "shuffles" should "yield a permutation of the original items" in {
+    itemsTrials.withLimit(50).supplyTo { items =>
+      api.shuffles(items).withLimit(10).supplyTo { shuffled =>
+        shuffled should contain theSameElementsAs items
+        shuffled.size should be(items.size)
+      }
+    }
+  }
+
+  it should "preserve the container type of the shuffles" in {
+    val vectorItems = Vector(1, 2, 3)
+    api.shuffles(vectorItems).withLimit(1).supplyTo { shuffled =>
+      shuffled shouldBe a[Vector[_]]
+    }
+
+    val listItems = List(1, 2, 3)
+    api.shuffles(listItems).withLimit(1).supplyTo { shuffled =>
+      shuffled shouldBe a[List[_]]
+    }
+  }
+
+  it should "eventually yield all possible shuffles" in {
+    val items = Vector(1, 2, 3)
+    val expectedNumberOfShuffles = 6 // 3!
+    val shuffles =
+      api.shuffles(items).withLimit(100).asIterator().to(LazyList).toSet
+    shuffles should have size expectedNumberOfShuffles
+  }
+
+  it should "handle empty collections" in {
+    val emptyItems = Vector.empty[Int]
+    api.shuffles(emptyItems).withLimit(1).supplyTo { shuffled =>
+      shuffled shouldBe empty
+    }
+  }
+}

--- a/core-library/src/test/scala/com/sageserpent/americium/SplitsIntoPiecesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/SplitsIntoPiecesTest.scala
@@ -3,13 +3,13 @@ package com.sageserpent.americium
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
+class SplitsIntoPiecesTest extends AnyFlatSpec with Matchers {
   val api = Trials.api
 
   private val itemsTrials: Trials[Vector[Int]] =
     api.integers.several[Vector[Int]]
 
-  "splitIntoPieces" should "yield pieces that concatenate to the original items" in {
+  "splitsIntoPieces" should "yield pieces that concatenate to the original items" in {
     val testCaseTrials = for {
       items <- itemsTrials
       overshootToForceSomeMandatoryEmptyPieces = 1 max items.size / 5
@@ -17,7 +17,7 @@ class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
         1,
         overshootToForceSomeMandatoryEmptyPieces + items.size
       )
-      pieces <- api.splitIntoPieces(items, numberOfPieces)
+      pieces <- api.splitsIntoPieces(items, numberOfPieces)
     } yield (items, numberOfPieces, pieces)
 
     testCaseTrials.withLimit(100).supplyTo {
@@ -29,21 +29,21 @@ class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
 
   it should "preserve the container type of the pieces" in {
     val vectorItems = Vector(1, 2, 3)
-    api.splitIntoPieces(vectorItems, 2).withLimit(1).supplyTo { pieces =>
+    api.splitsIntoPieces(vectorItems, 2).withLimit(1).supplyTo { pieces =>
       pieces.head shouldBe a[Vector[_]]
     }
 
     val listItems = List(1, 2, 3)
-    api.splitIntoPieces(listItems, 2).withLimit(1).supplyTo { pieces =>
+    api.splitsIntoPieces(listItems, 2).withLimit(1).supplyTo { pieces =>
       pieces.head shouldBe a[List[_]]
     }
   }
 
-  "splitIntoNonEmptyPieces specifying the number of pieces" should "yield non-empty pieces that concatenate to the original items" in {
+  "splitsIntoNonEmptyPieces specifying the number of pieces" should "yield non-empty pieces that concatenate to the original items" in {
     val testCaseTrials = for {
       items          <- itemsTrials.filter(_.nonEmpty)
       numberOfPieces <- api.integers(1, items.size)
-      pieces         <- api.splitIntoNonEmptyPieces(items, numberOfPieces)
+      pieces         <- api.splitsIntoNonEmptyPieces(items, numberOfPieces)
     } yield (items, numberOfPieces, pieces)
 
     testCaseTrials.withLimit(100).supplyTo {
@@ -54,10 +54,10 @@ class SplitIntoPiecesTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  "splitIntoNonEmptyPieces" should "yield non-empty pieces that concatenate to the original items" in {
+  "splitsIntoNonEmptyPieces" should "yield non-empty pieces that concatenate to the original items" in {
     val testCaseTrials = for {
       items          <- itemsTrials
-      pieces         <- api.splitIntoNonEmptyPieces(items)
+      pieces         <- api.splitsIntoNonEmptyPieces(items)
     } yield (items, pieces)
 
     testCaseTrials.withLimit(100).supplyTo {


### PR DESCRIPTION
The changes add a new `shuffles` method to the `TrialsApi` for both Scala and Java, providing an easy way to generate trials of shuffled collections. Following the library's convention for collection-yielding methods, the existing `splitIntoPieces` and `splitIntoNonEmptyPieces` were renamed to their plural forms (`splitsInto...`). In Scala, these methods were also enhanced to preserve the original container type using `collection.Factory`. Comprehensive tests were added/updated to verify these changes.

---
*PR created automatically by Jules for task [10078336160472112171](https://jules.google.com/task/10078336160472112171) started by @sageserpent-open*