### PR TITLE
Migrate Wiki Content to Microsite

### DIFF
--- a/gh-pages/docs/wiki-content/awkward-tests.md
+++ b/gh-pages/docs/wiki-content/awkward-tests.md
@@ -1,0 +1,557 @@
+---
+layout: default
+title: "Awkward tests"
+parent: Wiki Content
+nav_order: 8
+---
+
+# Awkward tests
+{: .no_toc }
+
+Sometimes the test doesn't even want to run itself
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Let's earn our bonuses and do some high-end financial software implementation:
+
+```java
+interface CashBoxAccounts {
+    class AccountAlreadyExists extends RuntimeException {
+        private UUID accountId;
+
+        public AccountAlreadyExists(UUID accountId) {
+
+            this.accountId = accountId;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Account already exists for %s.",
+                                 accountId);
+        }
+    }
+
+    class AccountDoesNotExist extends RuntimeException {
+        private UUID accountId;
+
+        public AccountDoesNotExist(UUID accountId) {
+
+            this.accountId = accountId;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Account does not exist for %s.",
+                                 accountId);
+        }
+    }
+
+    class InsufficientFunds extends RuntimeException {
+        private UUID accountId;
+        private int requestedAmount;
+        private int currentBalance;
+
+        public InsufficientFunds(UUID accountId, int requestedAmount,
+                                 int currentBalance) {
+            this.accountId = accountId;
+            this.requestedAmount = requestedAmount;
+            this.currentBalance = currentBalance;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "Insufficient funds in account %s for requested" +
+                    " amount: %s. Current balance is: %s.",
+                    accountId,
+                    requestedAmount,
+                    currentBalance);
+        }
+    }
+
+    /**
+     * Opens an account.
+     * @throws {@link CashBoxAccounts.AccountAlreadyExists} if there is
+     * an existing account using {@code accountId}.
+     * @apiNote {@code cash} must be positive.
+     */
+    void open(UUID accountId, int cash) throws AccountAlreadyExists;
+
+    /**
+     * Deposit cash in an account.
+     * @throws {@link CashBoxAccounts.AccountDoesNotExist} if there is
+     * no existing account using {@code accountId}.
+     * @apiNote {@code cash} must be positive.
+     */
+    void deposit(UUID accountId, int cash) throws AccountDoesNotExist;
+
+    /**
+     * Attempt to withdraw cash from an account.
+     * @throws InsufficientFunds if the current balance does not cover
+     * {@code requestedAmount}.
+     * @throws {@link CashBoxAccounts.AccountDoesNotExist} if there is
+     * no existing account using {@code accountId}.
+     * @apiNote {@code requestedAmount} must be positive.
+     */
+    void withdraw(UUID accountId, int requestedAmount)
+            throws AccountDoesNotExist, InsufficientFunds;
+
+    /**
+     * Closes the account, forgetting {@code accountId}
+     * @param accountId
+     * @throws {@link CashBoxAccounts.AccountDoesNotExist} if there is
+     * no existing account using {@code accountId}.
+     * @return The final balance.
+     */
+    int close(UUID accountId) throws AccountDoesNotExist;
+}
+
+public class Bank {
+    private final Map<UUID, Integer> accountBalances = new HashMap<>();
+
+    /**
+     * Execute a transaction, supplying a {@link CashBoxAccounts} that
+     * is valid for the duration of the transaction.
+     * @apiNote Commits the effects made on the {@link CashBoxAccounts}
+     * on successful completion of {@code action}. Any exception thrown
+     * by {@code action} rolls the effects back.
+     * @implNote Accounts may earn interest and log a transaction
+     * history, so the implementation should have some notion of time to
+     * mark the effects of a transaction. This is presumably UTC.
+     * @param action
+     */
+    public void transaction(Consumer<CashBoxAccounts> action) {
+        final CashBoxAccounts cashBoxAccounts =
+                new CashBoxAccounts() {
+                    @Override
+                    public void open(UUID accountId, int cash)
+                            throws AccountAlreadyExists {
+                        Preconditions.checkArgument(0 < cash);
+                        if (null !=
+                            accountBalances.putIfAbsent(accountId, cash)) {
+                            throw new AccountAlreadyExists(accountId);
+                        }
+                    }
+
+                    @Override
+                    public void deposit(UUID accountId, int cash)
+                            throws AccountDoesNotExist {
+                        Preconditions.checkArgument(0 < cash);
+                        if (null == accountBalances.computeIfPresent(
+                                accountId,
+                                (unused, balance) -> cash + balance)) {
+                            throw new AccountDoesNotExist(accountId);
+                        }
+                    }
+
+                    @Override
+                    public void withdraw(UUID accountId,
+                                         int requestedAmount)
+                            throws InsufficientFunds, AccountDoesNotExist {
+                        Preconditions.checkArgument(0 < requestedAmount);
+                        if (null == accountBalances.computeIfPresent(
+                                accountId,
+                                (unused, balance) -> {
+                                    if (requestedAmount <= balance) {
+                                        return balance - requestedAmount;
+                                    } else throw new InsufficientFunds(
+                                            accountId,
+                                            requestedAmount,
+                                            balance);
+                                })) {
+                            throw new AccountDoesNotExist(accountId);
+                        }
+                    }
+
+                    @Override
+                    public int close(UUID accountId)
+                            throws AccountDoesNotExist {
+                        return Optional
+                                .of(accountBalances.get(accountId))
+                                .orElseThrow(() -> new AccountDoesNotExist(
+                                        accountId));
+                    }
+                };
+
+        action.accept(cashBoxAccounts);
+    }
+}
+```
+
+What have we got here? A model of simple cash accounts - so no inter-account transfers, external payments, nostros and vostros. Lots of cash boxes, with UUIDs to distinguish them. How cash is deposited or withdrawn can vary - might be at a bank counter, might be an ATM.
+
+There is a transactional API that executes actions on the accounts; the interface of `CashBoxAccounts` is a passive one - it records the effect of an operation, but doesn't engage with other systems to realise the effect in the real world.
+
+So when an ATM dispenses money, that is because some code in an action first called `.withdraw` and then instructed the ATM to dispense the cash as a following step in that action. If `.withdraw` fails, there is no effect and no cash is dispensed; if the cash can't be dispensed in the real world, the effect of the transaction on the account is rolled back. Note that our implementation here doesn't actually implement rollback yet, but we have to start somewhere.
+
+What's a good property to test at this point? If a cashbox account doesn't allow an overdraft and there are no transaction charges, then we would expect the customer to be able to close the account at any time regardless of what happened before.
+
+We are trying to come up with a property that is not simply a replication of the internal logic of the system under test, so we don't have the test plan keep track of deposits and withdrawals, as that would be simply replicating logic we're testing in the test itself. In fact, we won't in general actually know exactly how much money should be in the account because of interest, although that isn't baked into the implementation yet.
+
+A test case for this is a plan consisting of steps - the plan will execute the steps that model an account's lifecycle from being opened to being closed and then apply expectations checking. This is a common pattern for testing stateful systems, and is accommodated nicely by Americium. Let's start with a test for just one account - we have a lump sum of cash that is distributed in separate deposits; we also attempt to withdraw sums of cash up to the lump sum in value. So all in all, we should have either no money at all when we close the account, or perhaps a positive amount due to interest.
+
+This is a big one:
+
+```java
+class TestPlan {
+    TestPlan(UUID accountId, int availableToDeposit,
+             int targetToWithdraw, Step step) {
+        this.accountId = accountId;
+        this.availableToDeposit = availableToDeposit;
+        this.targetToWithdraw = targetToWithdraw;
+        this.step = step;
+    }
+
+    static class Step {
+        final Consumer<CashBoxAccounts> action;
+        final Optional<Step> followingStep;
+
+        Step(Consumer<CashBoxAccounts> action,
+             Optional<TestPlan.Step> followingStep) {
+            this.action = action;
+            this.followingStep = followingStep;
+        }
+
+        void executeUsing(Bank bank) {
+            bank.transaction(action);
+
+            // This is costly in terms of stack space, but is only test
+            // code, so....
+            followingStep.ifPresent(value -> value.executeUsing(bank));
+        }
+    }
+
+    private Step followingStep(Consumer<CashBoxAccounts> action) {
+        return new Step(action, Optional.of(step));
+    }
+
+    private final UUID accountId;
+
+    private final int availableToDeposit;
+
+    private final int targetToWithdraw;
+
+    private final Step step;
+
+    public static TestPlan closure(UUID accountId,
+                                   int lumpSum,
+                                   int expectedFinalBalance) {
+        Preconditions.checkArgument(expectedFinalBalance <= lumpSum);
+
+        return new TestPlan(accountId,
+                            lumpSum,
+                            lumpSum - expectedFinalBalance,
+                            new Step(cashBoxAccounts -> {
+                                final int closingBalance =
+                                        cashBoxAccounts.close(accountId);
+                                assertThat(closingBalance,
+                                           greaterThanOrEqualTo(
+                                                   expectedFinalBalance));
+                                System.out.format(
+                                        "Closed and validated," +
+                                        " expected final balance is %d," +
+                                        " closing balance is: %d.\n",
+                                        expectedFinalBalance,
+                                        closingBalance);
+                            }, Optional.empty()));
+    }
+
+    public TestPlan deposition(int cash) {
+        Preconditions.checkArgument(1 <= availableToDeposit);
+
+        return new TestPlan(accountId,
+                            availableToDeposit - cash,
+                            targetToWithdraw,
+                            followingStep(cashBoxAccounts -> {
+                                cashBoxAccounts.deposit(accountId, cash);
+                                System.out.println("Deposited.");
+                            }));
+    }
+
+    public TestPlan withdrawal(int requestedAmount) {
+        Preconditions.checkArgument(1 <= targetToWithdraw);
+
+        return new TestPlan(accountId,
+                            availableToDeposit,
+                            targetToWithdraw - requestedAmount,
+                            followingStep(cashBoxAccounts -> {
+                                cashBoxAccounts.withdraw(accountId,
+                                                         requestedAmount);
+                                System.out.println("Withdrawn.");
+                            }));
+    }
+
+    public TestPlan opening() {
+        Preconditions.checkArgument(0 == targetToWithdraw);
+
+        return new TestPlan(accountId,
+                            0,
+                            0,
+                            followingStep(cashBoxAccounts -> {
+                                cashBoxAccounts.open(accountId,
+                                                     availableToDeposit);
+                                System.out.println("Opened.");
+                            }));
+    }
+
+    public Trials<TestPlan> extend() {
+        if (0 == targetToWithdraw) {
+            return api().only(opening());
+        }
+
+        final List<Trials<TestPlan>> choices =
+                new LinkedList();
+
+        if (2 <= availableToDeposit) {
+            choices.add(api().integers(1, availableToDeposit - 1)
+                             .map(this::deposition));
+        }
+
+        if (1 <= targetToWithdraw) {
+            choices.add(api().integers(1, targetToWithdraw)
+                             .map(this::withdrawal));
+        }
+
+        return api()
+                .alternate(choices)
+                .flatMap(plan -> plan.extend());
+    }
+
+    public void executeUsing(Bank bank) {
+        step.executeUsing(bank);
+    }
+}
+
+
+final Trials<TestPlan> testPlans = api()
+        .integers(1, 1000)
+        .flatMap(lumpSum -> api()
+                .integers(1, lumpSum)
+                .flatMap(expectedFinalBalance -> TestPlan
+                        .closure(UUID.randomUUID(),
+                                 lumpSum,
+                                 expectedFinalBalance)
+                        .extend()));
+
+try {
+    testPlans.withLimit(10).supplyTo(testPlan -> {
+        try {
+            testPlan.executeUsing(new Bank());
+        } catch (Throwable t) {
+            System.out.println(t);
+            throw t;
+        }
+    });
+} catch (TrialsFactoring.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+What do we see?
+
+```
+Opened.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Closed and validated, expected final balance is 32, closing balance is: 32.
+Opened.
+Insufficient funds in account 5120f880-6d9b-4e58-bffa-2599e00e14fe for requested amount: 9. Current balance is: 1.
+Opened.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Closed and validated, expected final balance is 211, closing balance is: 211.
+Opened.
+Withdrawn.
+Insufficient funds in account c1b7b523-3a39-45d9-83bd-190ab715e748 for requested amount: 10. Current balance is: 3.
+
+etc...
+```
+
+This is awkward - it seems that most of the time, the trials are passing, but every now and then we have a badly constructed test plan that tries to overdraw from the account, so the _test itself is causing a fault_.
+
+In our haste to avoid duplicating the logic of the system under test, we have allowed test plans to split the deposits and withdrawals in arbitrary ways - although they both total to the lump sum, there is no coordination between the two, so a test plan's step can try to overdraw partway through the account's lifecycle.
+
+Let's allow the test to reject bad test cases; this aborts the currently executing trial, but allows supply of further test cases to proceed as usual:
+
+```java
+try {
+    testPlans.withLimit(10).supplyTo(testPlan -> {
+        try {
+            testPlan.executeUsing(new Bank());
+        } catch (CashBoxAccounts.InsufficientFunds e) {
+            Trials.reject();
+        } catch (Throwable t) {
+            System.out.println(t);
+            throw t;
+        }
+    });
+} catch (TrialsFactoring.TrialException exception) {
+    System.out.println(exception);
+}
+```
+Now we see 10 trials with validated account lifecycles:
+
+```
+Opened.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Closed and validated, expected final balance is 32, closing balance is: 32.
+Opened.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Closed and validated, expected final balance is 293, closing balance is: 293.
+Opened.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Closed and validated, expected final balance is 589, closing balance is: 589.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Deposited.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Closed and validated, expected final balance is 109, closing balance is: 109.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Withdrawn.
+Closed and validated, expected final balance is 440, closing balance is: 440.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Withdrawn.
+Opened.
+Opened.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Closed and validated, expected final balance is 681, closing balance is: 681.
+Opened.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Deposited.
+Closed and validated, expected final balance is 69, closing balance is: 69.
+Opened.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Deposited.
+Closed and validated, expected final balance is 70, closing balance is: 70.
+Opened.
+Withdrawn.
+Deposited.
+Withdrawn.
+Opened.
+Withdrawn.
+Deposited.
+Deposited.
+Deposited.
+Deposited.
+Closed and validated, expected final balance is 128, closing balance is: 128.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Opened.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Withdrawn.
+Deposited.
+Withdrawn.
+Withdrawn.
+Deposited.
+Deposited.
+Withdrawn.
+Closed and validated, expected final balance is 130, closing balance is: 130.
+```
+
+We see how rejection of a test case acts as a kind of last chance filtration in the test itself; Americium treats the rejected test case in the same way as it would a test case that didn't pass `.filter`.
+
+Hopefully it goes without saying that we shouldn't be too casual with rejection - it is possible that the `CashBoxAccounts.InsufficientFunds` exception might be thrown because of a genuine bug in the implementation. If a test yields nothing but rejections, this may be a sign that there is a genuine problem going on, either in the test itself or what it's testing!
+
+There is a variation on this technique supported by `Trials.whenever` - the idea here is to evaluate a guard precondition and depending on whether the precondition holds, execute some guarded test code, or reject the test case:
+
+```java
+Test.whenever(<some Boolean guard precondition>, () -> {<block of guarded test code>});
+```
+
+This wraps `Trials.reject` under the hood, but reads nicely in situations where it's easy to evaluate the precondition before actually hitting the 'real' test code.
+
+Before we move on, did you notice that there is a potential bug lurking in the `Bank` implementation? It certainly passes the test, but maybe we should write an extra test. (HINT: what would happen if we changed the test plans to allow two back-to-back lifecycles sharing the same account ID?)
+
+***
+Next topic: [JUnit5 Integration...]({% link docs/wiki-content/junit5-integration.md %})

--- a/gh-pages/docs/wiki-content/background.md
+++ b/gh-pages/docs/wiki-content/background.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: "How did this come about?"
+parent: Wiki Content
+nav_order: 15
+---
+
+# How did this come about?
+{: .no_toc }
+
+Sit down and let me tell you...
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Placeholder

--- a/gh-pages/docs/wiki-content/building-up-test-cases.md
+++ b/gh-pages/docs/wiki-content/building-up-test-cases.md
@@ -1,0 +1,294 @@
+---
+layout: default
+title: "Building up test cases"
+parent: Wiki Content
+nav_order: 3
+---
+
+# Building up test cases
+{: .no_toc }
+
+Collections, mapping, filtering, flat-mapping and recursion
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+It's great to be able to call on `TrialsApi` to provide canned trials of integers, longs, doubles, strings and Booleans; even better that we can supply our own choices of test cases to draw on, and mix between them as well as throwing in a special case. However, tests frequently require much more complex test cases that might be a fully configured system under test, perhaps interacting with some complex query or plan of interactions. If so, how do we build up these complex test cases?
+
+We have five possibilities:
+
+1. Make a trials of collections out of one (or several) trials of a base element type.
+2. Transform from a trials of one type to a trials of another - mapping.
+3. Filtering out test cases we don't want.
+4. Combine the test cases of several trials together to make a trials of a type assembled from the individual cases - flat-mapping.
+5. Putting the previous techniques together in a recursive definition of a trials.
+
+## Collections
+
+Let's test reducing a stream of integers by summation - surely we would expect positive integers to sum to a non-negative value?
+
+```java
+import static com.sageserpent.americium.java.Trials.api;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+final Trials<ImmutableList<Integer>> lists = api().integers(1, Integer.MAX_VALUE).immutableLists();
+
+lists.withLimit(100).supplyTo(list -> {
+    assertThat(list.stream().reduce(Integer::sum).orElse(0), greaterThanOrEqualTo(0));
+});
+```
+
+Um, no:
+
+```
+java.lang.AssertionError:
+Expected: a value equal to or greater than <0>
+     but: <-2117575447> was less than <0>
+lists.withLimit(100).supplyTo(list -> {
+    assertThat(list.stream().reduce(Integer::sum).orElse(0), greaterThanOrEqualTo(0));
+})
+
+Case:
+[1013174718, 1164217131]
+```
+
+Anyway, we called `Trials.immutableLists` on our `Trials<Integer>` and got a `Trials<ImmutableList<Integer>>`. This yields test cases that are lists of varying size from empty and singleton lists to very large ones indeed that are populated with elements drawn from the original trials instance.
+
+There are other such methods available - `.immutableSets`, `.immutableSortedSets`, `.immutableMaps`, `.immutableSortedMaps` and for the those who require the ultimate in custom collections, `.collections`.
+
+There is also a nice method `TrialsApi.immutableLists`:
+
+```java
+final Trials<ImmutableList<Integer>> lists = api().immutableLists(List.of(
+        api().choose(0, 1, 2),
+        api().choose(-1, -2),
+        api().only(99)));
+
+lists.withLimit(10).supplyTo(System.out::println);
+```
+
+You'll get the idea:
+
+```
+[0, -1, 99]
+[1, -1, 99]
+[2, -1, 99]
+[1, -2, 99]
+[0, -2, 99]
+[2, -2, 99]
+```
+
+Observe how Americium works its way through the Cartesian product of the various contributions from the underlying trials. Again, there is a `TrialsApi.collections` for those who need customised collections.
+
+## Mapping
+
+Let's revisit the example from the previous topic:
+
+```java
+final Trials<Integer> evens = api().integers(0, 19).map(x -> 2 * x);
+
+final Trials<Integer> odds = api().integers(0, 19).map(x -> 1 + 2 * x);
+
+final Trials<Integer> trials =
+        api().alternateWithWeights(Map.entry(1, evens), Map.entry(2, odds));
+
+
+trials.withLimit(10).supplyTo(System.out::println);
+```
+
+This gives us:
+
+```
+18
+3
+33
+19
+31
+36
+37
+30
+21
+1
+```
+
+Again, the odd numbers occur roughly twice as often as the even numbers. See how we have used `.map` to transform the result of `.integers` into two completely distinct trials instances - one generating even numbers and the other odd numbers.
+
+We could also transform the type if needs be:
+
+```java
+final Trials<String> asteriskRuns =
+        api().choose(1, 2, 6, 9).map(repeats -> {
+            final StringBuffer buffer = new StringBuffer();
+
+            int countDown = repeats;
+
+            while (0 < countDown--) {
+                buffer.append('*');
+            }
+
+            return buffer.toString();
+        });
+
+
+asteriskRuns.withLimit(10).supplyTo(System.out::println);
+```
+
+Yielding:
+
+```
+*********
+******
+*
+**
+```
+
+## Filtering
+
+When we made trials for even and odd numbers above, we used a synthetic approach - the mapping forces the trials to generate the right kind of numbers by construction. We can also use a more brute-force approach and throw away test cases that don't suit:
+
+```java
+final Trials<Integer> numbers = api().integers(0, 39);
+
+final Trials<Integer> evens = numbers.filter(x -> 0 == x % 2);
+
+final Trials<Integer> odds = numbers.filter(x -> 1 == x % 2);
+```
+
+Be careful with this approach - as long as most cases pass the filter, all will be well, but if the filter works by sieving through the vast majority of test cases in search of a tiny number of golden nuggets, this is likely to exhaust Americium and you won't see many trials being executed. Prefer the synthetic approach in those cases!
+
+## Flat-mapping
+
+Let's list strings where there must be at least 1 string item and at most 10:
+
+```java
+final Trials<ImmutableList<String>> stringLists = api()
+        .integers(1, 10)
+        .flatMap(api().strings()::immutableListsOfSize);
+
+stringLists.withLimit(10).supplyTo(System.out::println);
+```
+See how we take the output from one trials, the `api.integers(1, 10)` and use it as a length constraint on the specification of another trials instance that yields lists. We do this via a method reference, `api().strings()::immutableListsOfSize` that implicitly takes the length - we could also have written `length -> api().strings().immutableListsOfSize(length)`.
+
+We can go crazy and nest flat-maps:
+
+```java
+final Trials<ImmutableList<String>> filenameLists = api()
+        .integers(1, 10)
+        .flatMap(api()
+                         .choose("FilenameOne",
+                                 "FilenameTwo",
+                                 "FilenameThree")
+                         .flatMap(stem -> api()
+                                 .choose("Huey",
+                                         "Duey",
+                                         "Louie")
+                                 .map(suffix -> stem + "." +
+                                                suffix))::immutableListsOfSize);
+
+filenameLists.withLimit(3).supplyTo(System.out::println);
+```
+
+We get this:
+
+```
+[FilenameOne.Duey, FilenameTwo.Louie, FilenameThree.Duey, FilenameTwo.Huey, FilenameOne.Huey, FilenameTwo.Duey, FilenameThree.Huey]
+[FilenameTwo.Huey, FilenameOne.Duey, FilenameTwo.Huey, FilenameTwo.Huey, FilenameTwo.Duey, FilenameThree.Duey, FilenameOne.Huey, FilenameTwo.Huey]
+[FilenameThree.Louie, FilenameThree.Louie, FilenameTwo.Duey, FilenameThree.Louie, FilenameOne.Duey, FilenameTwo.Huey]
+```
+
+The idea is to make a sequence of progressively nested flat-maps, where the parameters from any of the enclosing flat-maps can be used to control or contribute to the more nested ones; the end result then bubbles back up from the innermost trials instance in the flat-map sequence.
+
+Look carefully and see that the size parameter from the outer flat-mapping is used to control the trials made by `.immutableListsOfSize`, whereas the stem parameter from the inner flat-mapping contributes directly to the synthesis of a string inside a mapping.
+
+Typically, the last entry in the chain only needs a call to `.map` to make the final trials instance, but this is not a hard-and-fast rule.
+
+## Recursion
+
+Putting these ideas together, let's build up a trials that supplies string expression test cases for a calculator:
+
+```java
+class Module {
+    public static Trials<String> calculation() {
+        final Trials<String> constants =
+                api().integers(1, 100).map(x -> x.toString());
+
+        final Trials<String> unaryOperatorExpression =
+                calculation().map(expression -> String.format("-(%s)",
+                                                             expression));
+
+        final Trials<String> binaryOperatorExpression =
+                calculation().flatMap(lhs -> api()
+                        .choose("+", "-", "*", "/")
+                        .flatMap(operator -> calculation().map(rhs -> String.format(
+                                "(%s) %s (%s)",
+                                lhs,
+                                operator,
+                                rhs))));
+
+        return api().alternate(constants,
+                               unaryOperatorExpression,
+                               binaryOperatorExpression);
+    }
+}
+
+Module.calculation().withLimit(10).supplyTo(System.out::println);
+```
+
+This all seems straightforward enough - but it doesn't work, because of infinite recursion. Oops.
+
+We can remedy this by introducing delayed evaluation:
+
+```java
+class Module {
+    public static Trials<String> calculation() {
+        final Trials<String> constants =
+                api().integers(1, 100).map(x -> x.toString());
+
+        final Trials<String> unaryOperatorExpression =
+                api().delay(() -> calculation().map(expression -> String.format(
+                        "-(%s)",
+                        expression)));
+
+        final Trials<String> binaryOperatorExpression =
+                api().delay(() -> calculation().flatMap(lhs -> api()
+                        .choose("+", "-", "*", "/")
+                        .flatMap(operator -> calculation().map(rhs -> String.format(
+                                "(%s) %s (%s)",
+                                lhs,
+                                operator,
+                                rhs)))));
+
+        return api().alternate(constants,
+                               unaryOperatorExpression,
+                               binaryOperatorExpression);
+    }
+}
+```
+
+Now it works - delaying the recursive calls with `TrialsApi.delay` prevents direct infinite recursion; instead the recursion is done on demand as Americium unfolds the various alternatives. Note that only the leading recursive calls need to be delayed - those within a flat-map are already implicitly delayed by virtue of being within a lambda expression.
+
+The result is a bit rough around the edges, but can be improved - try experimenting with passing context down the calls to `Module.calculation`:
+
+```
+49
+(-(-(14))) * (-(-((89) + (-(61)))))
+-(-(-(-(85))))
+-(7)
+71
+-((-(((-(-(67))) / (20)) * (-(-(-(-(-(41)))))))) / (-((-((49) * ((-(77)) / ((-(-((45) / (56)))) - ((22) - ((78) / (23))))))) / (-((-(-(-(-(-(49)))))) * (94))))))
+9
+(49) + (((57) / (64)) - (31))
+-(22)
+50
+```
+
+***
+Next topic: [Multi parameter tests...]({% link docs/wiki-content/multi-parameter-tests.md %})

--- a/gh-pages/docs/wiki-content/competition.md
+++ b/gh-pages/docs/wiki-content/competition.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: "The competition"
+parent: Wiki Content
+nav_order: 11
+---
+
+# The competition
+{: .no_toc }
+
+Oh, that bunch?
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Americium fits in a wider ecosystem of property based testing tools.
+
+A lot of these are based on a Haskell implementation, QuickCheck, and there are some others that take their own approaches, including Americium itself.
+
+## Java
+
+1. [Jqwik](https://jqwik.net/) - The author [Johannes Link](https://github.com/jlink) maintains a nice challenge repository here: [The Shrinking Challenge](https://github.com/jlink/shrinking-challenge) that both Jqwik and Americium have Java submissions to, along with other tools for other languages. Jqwik is a powerful tool, making heavy use of annotations and is intended solely for use with JUnit5 framework, using its own engine instead of the Jupiter one. Like Americium, shrinking is integrated, so comes for free. The documentation is very comprehensive. Like Americium, it is agnostic about the assertion language, but is more prescriptive about test structure.
+
+1. [Quick Theories](https://github.com/quicktheories/QuickTheories) - not in the shrinking challenge, but again, shrinking is integrated. It uses a DSL based approach like Americium, and allows breakout from its own assertion language to using others. There is no integration with JUnit5 other than simply embedding a 'theory' into a JUnit test - this looks rather like using Americium's `.supplyTo` within a conventional `@Test` JUnt5 test.
+
+1. [JUnit-Quickcheck](http://pholser.github.io/junit-quickcheck/site/1.0/) - not in the shrinking challenge, and follows the approach of QuickCheck, so you have to write your own shrinkage helpers if your test cases are of custom types. It integrates with JUnit5 using the Jupiter engine, and makes use of annotations.
+
+1. [Vavr Test](https://docs.vavr.io/#_property_checking) - does not support shrinking. The website documentation is very sparse - go look at the code (which has good Javadoc). It is a port of the core concepts of Scalacheck to Java, using the Vavr framework, even leaner and meaner than Americium!
+
+## Scala
+
+1.  [Scalacheck](https://scalacheck.org/) The incumbent tool in the Scala world. Can be used standalone or integrated with Scalatest. Documentation is fairly good, covering the basics; the assumption is that if you use Scala, most of the monadic DSL will be second nature. Not in the shrinking challenge, and as this follows the QuickCheck approach, you have to write your own shrinkage helpers if your test cases are of custom types - the defaults ones can break and are disabled by default these days. Has its own assertion language, but the Scalatest integration uses Scalatest assertions instead.
+
+1. [Hedgehog](https://hedgehogqa.github.io/scala-hedgehog/) Lean and mean DSL approach, with integrated shrinking and its own assertion language - not in the shrinking challenge. Documentation is good. Has integrations with Minitest and MUnit.
+
+1. [Scalaprops](https://github.com/scalaprops/scalaprops)
+
+1. [Nyaya](https://github.com/japgolly/nyaya)
+
+1. [ZioTest](https://zio.dev/reference/test/property-testing/)
+
+There are several other such tools in the aforementioned shrinking challenge, including [Hypothesis](https://github.com/HypothesisWorks/hypothesis) for Python folk, so if you came here but had another language in mind, here's the link again: [The Shrinking Challenge](https://github.com/jlink/shrinking-challenge).
+
+
+***
+Next topic: [Arrived from Scalacheck?...]({% link docs/wiki-content/from-scalacheck.md %})

--- a/gh-pages/docs/wiki-content/configuration.md
+++ b/gh-pages/docs/wiki-content/configuration.md
@@ -1,0 +1,299 @@
+---
+layout: default
+title: "Configuration buttons, dials and levers"
+parent: Wiki Content
+nav_order: 7
+---
+
+# Configuration buttons, dials and levers
+{: .no_toc }
+
+Case limit strategies, seeding, complexity, controlling shrinking
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+## Case Limit Strategies
+
+Remember that test that failed with strings ending in "are" from the previous topic? Let's mess around and have the test fail if "are" comes anywhere in the string - but again, we don't allow just plain "are" by itself:
+
+```java
+try {
+    final String suffix = "are";
+
+    final int suffixLength = suffix.length();
+
+    api().characters('a', 'z').collections(Builder::stringBuilder).filter(caze -> caze.length() >
+                                                                                  suffixLength).withLimit(20000).supplyTo(input -> {
+        try {
+            assertThat(input, not(containsString(suffix)));
+        } catch (Throwable throwable) {
+            System.out.println(input);
+            throw throwable;
+        }
+    });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+This test drags on for a **long** time, and yields:
+
+```
+ared
+arew
+gare
+qare
+tare
+pare
+arev
+area
+arem
+arec
+care
+iare
+eare
+jare
+aret
+bare
+arei
+ares
+hare
+areo
+arex
+arek
+sare
+areb
+aren
+uare
+ware
+fare
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: not a string containing "are"
+     but: was "fare"
+```
+
+We've lost "rare" and ended up with "fare", which is a good enough trade. What a long time that test took to run, though. Maybe this was connected to using a limit of 20000 - perhaps that was too much? We could mess around with the limit and see if we can still get a shrunk failing test case in a reasonable amount of time, but suppose instead that we start with a time budget in mind - we'll wait 5 seconds for a failure to be found and no more, we're busy people, time is money, gotta hustle, get out of the road:
+
+```java
+try {
+    final String suffix = "are";
+
+    final int suffixLength = suffix.length();
+
+    api()
+            .characters('a', 'z')
+            .collections(Builder::stringBuilder)
+            .filter(caze -> caze.length() >
+                            suffixLength)
+            .withStrategy(cycle -> CasesLimitStrategy.timed(
+                    Duration.ofSeconds(5)))
+            .supplyTo(input -> {
+                try {
+                    assertThat(input, not(containsString(suffix)));
+                } catch (Throwable throwable) {
+                    System.out.println(input);
+                    throw throwable;
+                }
+            });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+This results in:
+
+```
+ared
+arew
+gare
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: not a string containing "are"
+     but: was "gare"
+```
+
+From the point of view of the test case being shrunk, this is just as good as the previous offering, but took a lot less time.
+
+Now, if we actually time this test, it still takes longer than 5 seconds to run - so what's going on?
+
+Let's peek some more at the progress by modifying what's passed to `.withStrategy`:
+
+```java
+final Instant startTime = Instant.now();
+
+try {
+    final String suffix = "are";
+
+    final int suffixLength = suffix.length();
+
+    api()
+            .characters('a', 'z')
+            .collections(Builder::stringBuilder)
+            .filter(caze -> caze.length() >
+                            suffixLength)
+            .withStrategy(cycle -> {
+                final Instant rightNow = Instant.now();
+
+                System.out.format("Elapsed time in seconds: %s, number of previous cycles:  %s\n",
+                                  Duration
+                                          .between(startTime, rightNow)
+                                          .getSeconds(),
+                                  cycle.numberOfPreviousCycles());
+
+                return CasesLimitStrategy.timed(
+                        Duration.ofSeconds(5));
+            })
+            .supplyTo(input -> {
+                try {
+                    assertThat(input, not(containsString(suffix)));
+                } catch (Throwable throwable) {
+                    System.out.println(input);
+                    throw throwable;
+                }
+            });
+} catch (TrialsScaffolding.TrialException exception) {
+    final Instant rightNow = Instant.now();
+
+    System.out.format("Total elapsed time in seconds: %s\n",
+                      Duration
+                              .between(startTime, rightNow)
+                              .getSeconds());
+    System.out.println(exception);
+}
+```
+
+We can see elapsed times:
+
+```
+Elapsed time in seconds: 0, number of previous cycles:  0
+ared
+Elapsed time in seconds: 4, number of previous cycles:  1
+arew
+Elapsed time in seconds: 5, number of previous cycles:  2
+gare
+Elapsed time in seconds: 6, number of previous cycles:  3
+Elapsed time in seconds: 11, number of previous cycles:  4
+Total elapsed time in seconds: 16
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: not a string containing "are"
+     but: was "gare"
+```
+
+Aha! So Americium works in cycles - the strategy's time limit is applied to each cycle. The first cycle is the default one, if no failing trial is encountered then that's it. Otherwise Americium starts shrinking; each succeeding cycle represents an attempt by Americium to produce a failing trial at a new level of shrinkage - we see above that in this case all but the last two yielded a failure.
+
+In general, we can call `.withStrategy` with any callback that takes a `CaseSupplyCycle` - that tells us where we've got to overall - and returns a `CasesLimitStrategy` - this controls how long Americium will persevere with next cycle.
+
+There are two canned implementations of `CasesLimitStrategy` - the aforementioned `CasesLimitStrategy.timed` and `CasesLimitStrategy.counted`. The latter is given a limiting number of test cases to produce in the cycle, and a _maximum starvation ratio_.
+
+Starvation refers to potential test cases discarded by Americium because they don't pass filtration, are too complex (we'll get to this shortly), or are built up via duplicate recipes; these test cases do not result in trials. The ratio is between the number of test cases that result in starvation versus those that make it through to a trial, regardless of whether the trial is a success or failure. So a value of 0 would mean that we simply will not tolerate any starvation and will give up as soon as any takes place, whereas 1 would mean that we expect as many cases to be discarded as those that come to trial, so will keep going as long the starvation doesn't outpace the trials.
+
+## Using the fluent configuration API
+
+By default, Americium uses a fixed internal seed for its pseudorandom behaviour - this is what ultimately drives the variation in test cases from one trial to another in a call to `.supplyTo`. So by default, each time a test using Americium is run, it will see the same progression of test cases in its trials - well, at least up to the first failing trial or the end of the cycle.
+
+That's nice when we want to know that our tests are repeatable, but there is a tradeoff - sticking to the same test cases means that if we really want to cover a lot of trials, then we'll have to have a test that runs for a long time; this tends to be unpopular for both local development (we want fast feedback) and CI pipelines (we want new builds / deployments asap).
+
+Rather than sacrifice timeliness, we can cover a wider base of trials by allowing the seed to vary from one run to another. If we want explicit control of the seed, then we use a fluent configuration method in `SupplyToSyntax` - so this comes between the `.withLimit/withStrategy` and the `.supplyTo`:
+
+```<trials instance>.withLimit(10).withSeed(<some long value>).supplyTo(<test lambda>);```
+
+We can set the seed according to the date or CI build number, host name or whatever.
+
+In fact, we can just let Americium to this for us implicitly by setting a JVM property:
+
+```-Dtrials.nondeterministic=true```
+
+This will use `java.util.Random` in non-repeatable seed mode, so different runs should yield different progression of test cases (as long as the trials instance allows variation, that is). This property takes precedence over an explicit seed when set to true.
+
+Remember complexity being mentioned in the context of shrinkage? Americium imposes a complexity limit by default; this prevents it from generating monstrously long lists via `.immutableLists` etc - this is especially important if trials are formulated by recursion, as we have seen before in the calculator example.
+
+We configure an explicit complexity limit like this:
+
+```<trials instance>.withLimit(10).withComplexityLimit(<some integer value, at least 1>).supplyTo(<test lambda>);```
+
+There is a subtlety with setting a complexity limit: say we have a list of lists, where the nested lists all have a specified length:
+
+```java
+api()
+        .integers(1, 5)
+        .immutableListsOfSize(50)
+        .immutableLists()
+        .withLimit(10)
+        .withComplexityLimit(4)
+        .supplyTo(System.out::println);
+```
+
+Yes, crazy, but the customer is always right ... anyway, this yields:
+
+```
+[[3, 2, 4, 3, 3, 4, 3, 2, 2, 5, 2, 3, 3, 3, 3, 5, 2, 1, 5, 2, 1, 3, 4, 4, 3, 2, 3, 3, 1, 3, 3, 1, 2, 4, 3, 1, 3, 3, 4, 3, 4, 4, 4, 2, 2, 1, 2, 4, 4, 4], [5, 4, 3, 2, 5, 1, 5, 4, 2, 4, 2, 4, 4, 3, 5, 1, 2, 1, 2, 4, 4, 5, 5, 2, 3, 2, 2, 3, 2, 1, 4, 4, 5, 2, 4, 4, 3, 3, 5, 1, 1, 4, 2, 3, 4, 3, 1, 1, 1, 4], [4, 4, 5, 4, 2, 5, 4, 3, 3, 3, 2, 4, 2, 2, 3, 2, 3, 2, 4, 4, 4, 4, 2, 3, 3, 2, 4, 3, 3, 2, 5, 2, 2, 2, 3, 5, 5, 1, 2, 4, 1, 5, 3, 1, 5, 3, 4, 3, 4, 3]]
+[]
+[[4, 4, 3, 4, 2, 5, 3, 2, 3, 4, 1, 3, 2, 1, 4, 4, 2, 3, 2, 4, 3, 5, 2, 2, 4, 3, 2, 4, 3, 5, 4, 3, 3, 4, 3, 3, 4, 3, 3, 3, 4, 1, 4, 2, 2, 4, 3, 2, 3, 3]]
+[[2, 2, 4, 2, 3, 5, 4, 2, 3, 4, 2, 5, 4, 4, 3, 2, 3, 5, 2, 4, 3, 5, 2, 4, 2, 2, 5, 4, 2, 2, 2, 1, 3, 1, 2, 3, 2, 3, 4, 3, 2, 2, 1, 1, 4, 1, 2, 1, 5, 3]]
+[[2, 4, 1, 4, 2, 5, 5, 4, 4, 5, 3, 2, 3, 4, 1, 1, 1, 2, 4, 4, 2, 4, 2, 5, 2, 1, 1, 3, 2, 4, 3, 4, 3, 3, 2, 3, 1, 2, 3, 5, 4, 1, 1, 2, 2, 1, 3, 2, 2, 4]]
+[[4, 5, 2, 4, 3, 3, 3, 2, 3, 2, 2, 4, 2, 2, 3, 2, 4, 5, 2, 3, 3, 2, 4, 2, 5, 2, 4, 3, 3, 4, 4, 3, 2, 2, 1, 1, 3, 4, 3, 1, 4, 4, 4, 4, 3, 4, 4, 4, 4, 3]]
+[[3, 3, 3, 3, 4, 3, 5, 4, 1, 2, 2, 3, 4, 3, 2, 2, 4, 2, 4, 1, 4, 2, 4, 2, 3, 3, 3, 5, 5, 1, 4, 4, 3, 2, 3, 3, 4, 3, 2, 1, 2, 1, 4, 3, 2, 3, 1, 3, 4, 4]]
+[[2, 3, 3, 3, 2, 2, 3, 2, 5, 2, 4, 4, 4, 3, 2, 5, 2, 2, 4, 2, 5, 4, 1, 3, 4, 2, 5, 3, 2, 3, 2, 4, 5, 4, 2, 3, 3, 3, 5, 3, 4, 5, 2, 2, 5, 3, 2, 1, 3, 4], [2, 2, 2, 5, 3, 1, 3, 3, 5, 2, 2, 2, 2, 4, 4, 4, 5, 2, 1, 2, 3, 1, 1, 2, 4, 3, 3, 3, 3, 5, 3, 4, 3, 3, 2, 4, 4, 3, 1, 1, 4, 3, 1, 3, 4, 5, 5, 3, 4, 2], [1, 5, 2, 4, 4, 3, 4, 3, 1, 3, 5, 4, 4, 3, 1, 2, 4, 3, 5, 4, 3, 2, 2, 4, 3, 5, 4, 2, 5, 2, 4, 4, 3, 4, 3, 4, 4, 5, 1, 1, 4, 2, 3, 3, 4, 3, 5, 2, 2, 3]]
+[[5, 4, 2, 5, 2, 4, 1, 2, 2, 3, 4, 4, 2, 4, 2, 3, 2, 1, 2, 5, 2, 4, 2, 1, 4, 5, 4, 2, 3, 2, 1, 3, 2, 2, 4, 2, 3, 2, 1, 1, 4, 3, 2, 3, 2, 4, 3, 4, 3, 4]]
+[[2, 3, 4, 3, 4, 3, 3, 4, 5, 2, 5, 2, 3, 2, 2, 1, 2, 3, 2, 4, 3, 1, 4, 1, 2, 3, 4, 2, 5, 3, 1, 5, 2, 2, 1, 1, 4, 4, 4, 4, 2, 2, 1, 5, 3, 5, 1, 3, 2, 1], [4, 2, 3, 2, 4, 2, 3, 4, 4, 2, 3, 3, 5, 4, 1, 3, 3, 4, 2, 4, 3, 2, 5, 5, 4, 4, 2, 2, 1, 2, 3, 3, 1, 1, 4, 2, 4, 4, 4, 5, 3, 2, 2, 5, 4, 4, 5, 3, 3, 3], [2, 4, 3, 3, 4, 5, 4, 3, 1, 2, 3, 5, 3, 2, 2, 2, 2, 4, 1, 3, 5, 2, 4, 4, 3, 2, 3, 4, 2, 2, 2, 5, 1, 2, 4, 2, 4, 3, 2, 3, 3, 3, 4, 2, 2, 3, 4, 3, 3, 2]]
+```
+
+We see that the outer lists are constrained by the complexity limit, but the nested lists have leeway to achieve the desired length. Americium takes the view that if its asked to make a collection of a given size, then the user knows what they're doing and it should comply, but it will still heed the complexity limit elsewhere.
+
+This also holds for things nested inside fixed-size collections:
+
+```java
+    api()
+            .integers(1, 5)
+            .immutableLists()
+            .immutableListsOfSize(10)
+            .immutableLists()
+            .withLimit(15)
+            .withComplexityLimit(10)
+            .supplyTo(System.out::println);
+```
+
+We have increased the complexity limit a little to give the outermost and innermost lists a chance to be built, and we see:
+
+```
+[]
+[[[1, 3], [], [], [], [4, 4], [2, 1], [], [], [4], []]]
+[[[1], [2, 2], [], [], [], [], [], [4], [], []]]
+[[[], [], [2, 3, 1, 3], [5], [], [], [], [], [], [5]]]
+[[[2, 2, 1], [2, 2], [], [], [], [], [], [], [], []]]
+[[[4, 2, 4], [], [3], [], [2, 5], [4, 3, 1, 3], [2], [], [], [4, 2]]]
+[[[], [], [], [], [], [], [2, 2, 2], [4], [], []], [[5], [], [2, 2, 3], [1], [], [], [], [2, 1], [], []]]
+[[[5], [], [5], [5], [2], [], [], [2, 3], [3, 4], []]]
+[[[2], [], [3, 4], [4], [], [4], [3], [], [], []], [[], [], [], [], [2, 4], [], [5, 3, 3, 3], [], [], [2]]]
+[[[4, 4, 2, 3], [], [], [], [1], [], [4, 4], [], [], []]]
+[[[4], [], [4, 2, 4], [4], [4], [], [], [4], [1], [3]]]
+```
+
+The outermost and innermost lists don't get too big, but the intermediate lists are still comprised of precisely 10 items.
+
+Two more fluent configuration settings and we can take a rest ... both of these control shrinking.
+
+We can specify how many levels of successful shrinkage are applied like this:
+
+```<trials instance>.withLimit(10).withShrinkageAttemptsLimit(<some integer value>).supplyTo(<test lambda>);```
+
+If we use 0, then the original failing test case is the one Americium will throw an exception for - so no shrinkage at all. 1 allows one level of shrinkage to be applied, and so on.
+
+For the ultimate in shrinkage control, we have:
+
+```<trials instance>.withLimit(10).withShrinkageStop(<shrinkage stop>).supplyTo(<test lambda>);```
+
+It works in a similar fashion to the callback provided to `.withStrategy`, and both can be used in conjunction. Consult the `ShrinkageStop` interface's Javadoc.
+
+***
+Next topic: [Awkward tests...]({% link docs/wiki-content/awkward-tests.md %})

--- a/gh-pages/docs/wiki-content/design-and-implementation.md
+++ b/gh-pages/docs/wiki-content/design-and-implementation.md
@@ -1,0 +1,240 @@
+---
+layout: default
+title: "Design and Implementation"
+parent: Wiki Content
+nav_order: 14
+---
+
+# Design and Implementation
+{: .no_toc }
+
+Yes, do pay attention to the man behind the curtain
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Congratulations, you have reached the final topic - by now you are a seasoned expert in the practice of the Americium way.
+
+May you design by contract, and all your preconditions be met - that is your invariant.
+
+Perhaps you'd like to work on this project yourself? Let's have a chat about what's going on under the hood...
+
+## Building, Directory Layout and Releases
+
+Americium is built as an SBT project, using cross-platform support to target Scala 2.13 and Scala 3. The [gha-scala-library-release-workflow](https://github.com/guardian/gha-scala-library-release-workflow) is used to publish a library JAR to Sonatype, running as a manually-triggered CI action on GitHub.
+
+This workflow drives the `release` task in SBT, supplied by the plugin `sbt-release`. As mentioned in [`build.sbt`](https://raw.githubusercontent.com/sageserpent-open/americium/ad4d2f3d09f527441973d262c18b66e86631f124/build.sbt#L184), the support for cross-building from `sbt-release` is disabled; SBT's built-in cross-building is used instead.
+
+Sources are organised in typical Maven / SBT directory roots - thus published code sits in `./src/main/scala` for cross-platform shared Scala sources, `./src/main/scala-2.13` for sources specific to Scala 2.13, `./src/main/scala-3`for sources specific to Scala 3 and `./src/main/java` for Java code.
+
+There is a similar hierarchy under `.src/test`.
+
+## Artifacts (From 2.0.0)
+
+Americium is published as three separate artifacts:
+
+### 1. `americium` (Core Framework)
+The core framework for generating test cases with integrated shrinkage.
+
+**Packages:**
+- `com.sageserpent.americium` - Scala client APIs, API implementations and their tests
+- `com.sageserpent.americium.java` - Java client APIs, forwarding implementations and additional tests
+- `com.sageserpent.americium.examples` - Example tests (Scala)
+- `com.sageserpent.americium.java.examples` - Example tests (Java)
+- `com.sageserpent.americium.generation` - Low-level support for test case generation
+- `com.sageserpent.americium.storage` - Storage for recipe reproduction
+
+### 2. `americium-junit5` (JUnit5 Integration)
+Deep integration with JUnit5, allowing individual replay of test cases.
+
+**Packages:**
+- `com.sageserpent.americium.junit5` - tight JUnit5 integration via `dynamicTests` (Scala)
+- `com.sageserpent.americium.junit5.java` - loose JUnit5 integration via annotations and tight integration via `JUnit5` (Java)
+- `com.sageserpent.americium.junit5.storage` - Storage for JUnit5 replay
+
+### 3. `americium-utilities` (Utility Libraries)
+Handy utilities used by Americium that may be useful outside a testing context.
+
+**Packages:**
+- `com.sageserpent.americium.utilities` - General utilities
+
+**NOTE:** there is an asymmetry in that the Scala client APIs do not have a `.scala` sub-package, they were for historical reasons taken to be default as they were implemented first.
+
+**NOTE:** sources in the `.java` sub-package may be written in Java or Scala, even though they target Java clients.
+
+Releases are triggered manually off branch `master` via GitHub and after each release is published to Sonatype, the branch `checkTheLibrary` takes a merge *from* `master`, deleting all non-test sources in the merge and updating its version of `built.sbt` to reference the published version of Americium. This allows the same test suite to be used to validate the published artefacts. Branch `checkTheLibrary` should *never* be merged back into `master`, as that would delete all of the non-test sources - it plays constant catch-up with `master` instead.
+
+## `TrialsApi`
+
+There are parallel Scala and Java implementations of the Scala and Java forms of `TrialsApi`. The Java implementation simply delegates to the Scala API, using things like `Int.(un)box` to negotiate the gap between Scala's idea of a generic whose type parameter is a primitive type (`Int`) and Java's idea of all generic type parameters being reference types (thus `Integer`).
+
+Around the codebase in general you will also see use of the Java <-> Scala collection conversions in `scala.collection.convert`, both to convert a Java iterable or collection passed as an argument to the Java API to the Scala equivalent and in reverse where the test case type is a collection.
+
+The ultimate source of the API implementation objects is `TrialsApis`. As these objects are immutable, they are held as simple Scala val bindings and reused via calls to `Trials.api`. Note how the definition of `TrialsApis.javaApi` is tied to that of `TrialsApis.scalaApi` in a [forwarding implementation](https://raw.githubusercontent.com/sageserpent-open/americium/aab8e67bb2404f4eaadac5adf8d2303c59f7e38c/src/main/scala/com/sageserpent/americium/TrialsApis.scala#L7).
+
+The lowest level implementations of the Scala API mostly construct instances of `TrialsImplementation`, we'll come back to this later.
+
+In the meantime, observe how several of the methods in the Scala implementation use `.stream`, passing a custom `CaseFactory` to the call; let's talk about this next...
+
+## `CaseFactory`
+
+In its Scala guise:
+
+```scala
+trait CaseFactory[+Case] {
+  def apply(input: BigInt): Case
+
+  def lowerBoundInput: BigInt
+
+  def upperBoundInput: BigInt
+
+  def maximallyShrunkInput: BigInt
+}
+```
+
+This underpins the 'streaming' methods in `TrialsApi`, used to _generate_ test cases over some domain (contrast with `.choose` that picks from test cases given explicitly as a collection by the client code).
+
+`CaseFactory` has the notion of an output range over `Case`, which contains all the possible test cases that could be generated. The particular test case generated (via `.apply`) is controlled by an input domain over `BigInt`. The input domain is the entire interval of integers between `.lowerBoundInput` and `.upperBoundInput` - typically, the actual test case type of `Case` has a total ordering, say a numeric type; we expect `.apply` to be a monotonic increasing function of `BigInt` and the value of `.apply(maximallyShrunkInput)` to be the maximally shrunk value of the test case type.
+
+As Americium can consult the bounds of the input domain as well as `.maximallyShrunkInput` (which admittedly is a slightly confusing name - it is not the input that is maximally shrunk, rather the input that yields the maximally shrunk `Case`), then it can drive the case factory correctly to generate test cases.
+
+Observe the implementation of `TrialsApi.bytes`:
+
+```scala
+  override def bytes: TrialsImplementation[Byte] =
+    stream(new CaseFactory[Byte] {
+      override def apply(input: BigInt): Byte   = input.toByte
+      override def lowerBoundInput: BigInt      = Byte.MinValue
+      override def upperBoundInput: BigInt      = Byte.MaxValue
+      override def maximallyShrunkInput: BigInt = 0
+    })
+```
+
+See how in this case there is a simple narrowing conversion from domain `BigInt` to range `Byte`, and so the input domain bounds are chosen according to the bounds of the output range, `Byte`.
+
+What happens when we have the integral domain of `BigInt` being transformed into an output range of something like `BigDecimal` or `Double`, that while technically is a countable set, is still approximately an Archimedean field, so its values can get much closer together than 1?
+
+Observe the implementation of [`TrialsApi.bigDecimals`](https://raw.githubusercontent.com/sageserpent-open/americium/42fb2263d0fe331a10d9788706bbbcb53b2b194b/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala#L231). This takes the approach of using choosing either to stick with the interval `[Long.MinValue; Long.MaxValue]` if this can be easily interpolated to the actual bounds of the _test case range_ type passed to the method while still retaining a reasonable degree of precision. It it can't achieve at least a precision of `numberOfSubdivisionsOfDoubleUnity`, then the input domain is expanded beyond that of `Long` to give the desired minimum precision.
+
+There is some fancy footwork going on, in that the bounds and `.maximallyShrunkInput` have to transform to exactly the corresponding test case values. To achieve this we split the interpolation into two halves, one from the lower bound to the maximally shrunk value, the other from the maximally shrunk value to the upper bound, so we can ensure that the anchor points of the interpolation hit the desired test case values spot on.
+
+## `Trials`
+
+There are conversions between the two flavours of `Trials` - both APIs have a conversion method that yields a corresponding interface or trait in the other language. This actually yields the same object as `this`, only the nominal interface / trait type changes to reflect the crossover to the other language. Switching back and forth between the Java and Scala forms of `Trials` takes place in both the implementations of the Java forms of `TrialsApi` and `Trials`.
+
+Ultimately the implementation of both flavours of `Trials` is realised by two skeleton implementation traits specific to each flavour (`TrialsSkeletalImplementation`) and a concrete implementation class, `TrialsImplementation` that extends both of the skeleton traits. The skeleton traits house implementation boilerplate; the Java skeleton delegates to the Scala form of `Trials` via the aforementioned conversion methods, whereas the Scala skeleton is implemented as a combination of wrapping of `Generation` within `TrialsImplementation` and delegation to some stray methods in `TrialsImplementation`.
+
+As an aside, the skeleton traits are a [bit messy](https://github.com/sageserpent-open/americium/issues/60), but they do avoid sprawl in `TrialsImplementation`, which is pretty large in its own right. They also partition the overrides for the Scala and Java forms of `Trials` nicely where they have differing type signatures; those overrides left in `TrialsImplementation` are mostly common to both forms - see `.withLimit` and `.withStrategy` for example.
+
+`TrialsImplementation` is really a facade; it keeps hold of an instance of `Generation` which is the underlying state used to formulate test cases, sharing the generation with instances implementing `SupplyToSyntax` that it creates in calls to `.withStrategy`, `.withLimit(s)` (indirectly by delegation to `.withStrategy`) and `.withRecipe`.
+
+## `Generation` and its two Interpreters.
+
+`Trials` is a monadic type supporting mapping, flat-mapping and filtering. As far the clients of Americium are concerned, it offers the usual monadic composition approach, has lots of magic factory methods to make instances of it out of thin air (these are what `TrialsApi` offers) and then supplies test cases via conversion to `SupplyToSyntax`. In the case of calling `.withLimits(s)` and `.withStrategy`, potentially many different test cases can be produced, whereas for `.withRecipe` only one specific test case can ever be produced.
+
+The difference in behaviour for the two routes to supplying test cases is implemented by a free monad, `Generation` and its two interpreters. Using a free monad supports all of the API monadic operations using a straightforward delegation approach from the Scala skeleton implementation of `Trials`, wrapping the resulting instances of `Generation` back up in a `TrialsImplementation`.
+
+Having `Generation` distinct from `Trials` or its implementations is necessary, as `Generation` is simply a type definition around the Cats `Free` class hierarchy; the latter cannot be amended to implement `Trials` as an interface, not can it have additional methods added to it to support the complete set of methods in `Trials` over and above the monadic ones.
+
+So there are two levels of delegation going on: a Java trials instance delegates to a Scala trials instance, and the Scala trials instance delegates to an instance of `Generation`.
+
+In itself, a free monad serves only as a framework that provides boilerplate for the monadic operations and a way of integrating in 'magic' instances of the monad that _denote_ behaviour that gives the monad implementation its special flavour. By itself, it doesn't do anything other than allow monadic composition - all you get at the end is just another free monad instance. To make the magic happen - so in this situation, to supply test cases - we have to provide an interpreter that understands what those magic instances mean and make something of them.
+
+Let's break this down - what are these these magic free monad instances? How do the interpreters work?
+
+Look at [how a choice](https://raw.githubusercontent.com/sageserpent-open/americium/d0629045f87023a6cd6b7eaa204efb48f3dc9f2c/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala#L66) is implemented by the Scala form of `TrialsApi` - an instance of `TrialsImplementation` is created by an auxiliary constructor from a `GenerationOperation`, here it is a `Choice`. Each case class implementing `GenerationOperation` denotes some kind of magic - in this example, the choosing of a test case from a set of choices. The auxiliary constructor then lifts the `GenerationOperation` into an instance of `Generation` as per the free monad cookbook and thus provides the magical instance.
+
+You will see a bunch of these [generation operations](https://raw.githubusercontent.com/sageserpent-open/americium/d0629045f87023a6cd6b7eaa204efb48f3dc9f2c/src/main/scala/com/sageserpent/americium/generation/GenerationOperation.scala#L7), note that in themselves they are passive - they denote something magical and provide the information needed to perform that magic, so choices of data, or a case factory or whatever, but there is no implementation detail. That job falls to the interpreters...
+
+**NOTE**: if at this point you are wandering what a 'free monad', 'lifting' and 'interpreters', then take a look [at the Cats documentation](https://typelevel.org/cats/datatypes/freemonad.html). There are also some good explanations of free monads in various blog posts, like [this one](https://www.haskellforall.com/2012/06/you-could-have-invented-free-monads.html) for example.
+
+**NOTE**: if you're puzzling over the adjective 'magic' in connection with monadic instances, think of the difference between, say a Scala `Option` built via `1.pure[Option]` (using Cats syntax here - this is really `Some(1)` under the hood) and `None`. The first value is an option built via the `.pure` lifting operation, and is just an ordinary value wrapped up into an `Option` - the second is magical, as it denotes the absence of a payload and propagates through a series of maps, flat-maps and filters.
+
+In the same way, we can make a non-magical trials: `1.pure[Trials]`, this is really `TrialsApi.only(1)` under the hood. It is just a value wrapped up in a trials which will end up supplying precisely that value and nothing else - so no shrinkage either, and no complexity cost. On the other hand, `TrialsApi.integers` will supply randomly varying integers that permit shrinkage and count to the overall complexity metric, hence this is magical; similarly `TrialsApi.choose` and `TrialsApi.impossible` are also magical, the last of these being analogous to `None`.
+
+The two interpreters come into play via instances of `SupplyToSyntax`:
+
+1. Calling `Trials.withLimit(s)` or `Trials.withStrategy` creates an instance of `SupplyToSyntaxImplementation`, which is a method-local class defined in `TrialsImplementation.withStrategy`. This extends and completes a large body of hoisted implementation provided by `SupplyToSyntaxSkeletalImplementation`, including [its own interpreter](https://raw.githubusercontent.com/sageserpent-open/americium/0f32a19942c3f84fcfebf8f8eecc6c488f1de247/src/main/scala/com/sageserpent/americium/generation/SupplyToSyntaxSkeletalImplementation.scala#L513). `SupplyToSyntaxImplementation` couples the implementation inherited from `SupplyToSyntaxSkeletalImplementation` to the state of `TrialsImplementation`, principally to pick up `TrialsImplementation.generation`.
+2. Calling `Trials.withRecipe` creates an instance of an anonymous subclass of `SupplyToSyntax`; this implementation is very simple, so has not been excised from `TrialsImplementation` - in fact the interpreter it references is left as a helper [within `TrialsImplementation`](https://raw.githubusercontent.com/sageserpent-open/americium/c53549899b4929c1403bad4cb79d3b3e7af75f94/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala#L75).
+
+## Recipe Interpreter and `DecisionStages`
+
+Let's start with the interpreter that `.withRecipe` leads to - it's simpler and gently introduces some background. Looking at its [definition](https://raw.githubusercontent.com/sageserpent-open/americium/c53549899b4929c1403bad4cb79d3b3e7af75f94/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala#L75), we see it takes a `GenerationOperation` - so a denotation of choice, alternation or whatever and yields a `State` monadic value as provided by Cats.
+
+Each call to the interpreter builds a state transforming operation that is parked within a `State` - so the `GenerationOperation` denotes some magic, and the resulting `State` can actually _perform_ it later on.
+
+This interpreter is folded through `Trials.generation` which plays out whatever monadic operations where set up by client code into an  instance of `State`, using the interpreter to translate these operations into corresponding ones in `State`.
+
+The resulting instance of `State` is then run on a `DecisionStages` to apply the state transformations and yield a test case as the result. Easy! Only what does `DecisionStages` mean? What does the interpreter do for each denoted bit of magic?
+
+Cast your eyes around and you will see the interpreter is embedded in [`TrialsImplementation.reproduce`](https://raw.githubusercontent.com/sageserpent-open/americium/c53549899b4929c1403bad4cb79d3b3e7af75f94/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala#L68), which is an overload shadowing the implementation of `Trials.reproduce`. That second method takes a recipe, parses it into a `DecisionStages` and then delegates to the overload with the interpreter, so we realise that `DecisionStages` encodes a test case, presumably as a list of `Decision` instances.
+
+A `Decision` is some specific choice or specific input to a case factory; so what the interpreter does is to transform the state - a list of decisions that encodes a test case - by peeling off the leading decision, using the generation operation to provide context to execute that decision. So if for example we have a `ChoiceOf` decision, the interpreter will use the corresponding `Choice` generation operation to provide the possible choices of test case, selecting one with `ChoiceOf.index`.
+
+The effect of folding the interpreter and then running the state transformations on a `DecisionStages` is to run through all of the decisions and build corresponding parts of the test case. Those parts are put together by the `State` monadic operations that mirror the ones that originally were composed by the client.
+
+So if the client wrote `api.choose(1, 5, -3).map(_ * 9)`, then if a decision stages of `List(ChoiceOf(2))` is interpreted, this will select -3 and then pass it through a mapping operation mirrored in `State` to supply -27.
+
+In a similar fashion, a `FactoryInputOf` decision is used to feed input to a case factory provided by the generation operation to build up part of a test case.
+
+Bear in mind, the translation of the magic into state transformations is what the interpreter does - the mirroring of the monadic operations composed by the client comes from folding the interpreter; that part is what Cats' `Free` offers.
+
+## Generic Interpreter and `DecisionStagesInReverseOrder`
+
+Now for the big, scary one! This time the interpreter transforms a `GenerationOperation` into a `StateT` layered over `Option` - so the result of folding the interpreter yields an optional result, which is a pair of the state being transformed and a test case. This is in contrast with the interpreter used for test case reproduction, which always yields a test case (given a correct recipe) and which ignores the final state after folding.
+
+The [state being transformed](https://raw.githubusercontent.com/sageserpent-open/americium/0f32a19942c3f84fcfebf8f8eecc6c488f1de247/src/main/scala/com/sageserpent/americium/generation/SupplyToSyntaxSkeletalImplementation.scala#L253) is richer - it consists of an optional `DecisionsStages`, a `DecisionStagesInReverseOrder`, a complexity and a cost. With the exception of the first piece, all of these are _built up_ as the state is transformed; this is in contrast to the other interpreter which uses the state purely as a source of information - here the state is being for the most part defined in tandem with each part of the test case.
+
+The idea is for the interpreter to select parts of test case using the generation operation it is working one, using a pseudorandom behaviour to perform either selection from a choice or feeding of an input to a case factory. This by itself is enough to generate the test case, so why transform the state?
+
+Well, for one thing, if we want to reproduce a test case, we will need the `DecisionStages` to drive this in the other interpreter - so as the interpreter selects a choice or feeds a case factory input, it records what is did in a decision and adds it to a list in reverse order, namely `DecisionStagesInReverseOrder`. Remember that the other interpreter picks apart a `DecisionStages` from left to right - here the interpreter is adding the decision stages left to right, so they are defined in reverse order.
+
+**NOTE**: `DecisionStagesInReverseOrder` is _not_ a simple list, rather it is a _hash-consed_ difference list, this is done so that reversing the list can be deferred as long as possible and avoids a very nasty performance hit where `DecisionStagesInReverseOrder` is used a a key when detecting duplicate test case formulations - it is cheap to compute the hash of a hash-consed data structure.
+
+Not only does the state need to track the decision stages, it also needs to keep track of the complexity of the test case, so that a complexity limit can be applied as a test case is being formulated. At first glance, it appears that the complexity is simply the number of decision stages being recorded, but it is possible to suspend the complexity count in order to allow generation of explicitly sized collections; this requires the complexity count to be decoupled from the number of decision stages in places.
+
+There is also a cost, and this is used as part of shrinkage. In fact, shrinkage can also make use of the decision stages recorded to potentially reproduce a test case, this is what the optional part of the state is for - they allow previously recorded decision stages to be recycled back into subsequent calls to the interpreter to guide shrinkage.
+
+## Shrinkage
+
+Shrinkage of a test case takes place via two coordinated activities within `SupplyToSyntaxSkeletalImplementation` - at a high level, there is a Fs2 `Stream` that grabs test cases from the interpreter and supplies then to the test code; this stream monitors whether the test succeeds or fails for a given trial execution and can influence the upstream generation of test cases done by [`.cases`](https://raw.githubusercontent.com/sageserpent-open/americium/0f32a19942c3f84fcfebf8f8eecc6c488f1de247/src/main/scala/com/sageserpent/americium/generation/SupplyToSyntaxSkeletalImplementation.scala#L233).
+
+At a low level, the interpreter's generation of a test case is modulated by a context held by its enclosing method, namely `.cases` - this fixes:
+
+1. The scale deflation level.
+1. The decision stages to guide shrinkage.
+
+Shrinkage takes place in two ways in Americium - firstly, if a test case is produced via a `CaseFactory`, then as mentioned above, the case factory has bounds for its inputs and a preferred maximally shrunk input. The scale deflation level modulates the interpreter so that instead of using an input chosen randomly between the lower and upper bound, it will constrict the range of the input, bringing the effective bounds closer together around the maximally shrunk input as the deflation level increases to a maximum. This means a test case built out of many streamed parts is shrunk down to a test case built out of shrunk parts, as long as shrinkage keeps discovering better failing test cases.
+
+Secondly, guided shrinkage can occur - here the decision stages recorded when a failing test case was built up are used as a template to constrain the generation of further test cases. This is similar to the reproduction of a failing test case described above, only this time the interpreter mixes up the approaches - for a choice, it will try to reproduce the exact same choice for the guide decision if the context of the test case currently being built permits that, in other words, the new test case isn't radically different in how it is formulated from the guide test case. For a case factory, the interpreter will try to mix two approaches - the first is to use the guide decision as a bound and make a random input between the guide decision's bound and the maximally shrunk input, the second is the aforementioned use of scale deflation, which ignores the guide decision completely.
+
+The higher level logic starts with just scale deflation, but if progressive scale deflation fails to improve on the previous shrunk test case, it will switch to _panic mode_ and start to perform guided shrinkage. If guided shrinkage succeeds in finding a better failing test case, shrinkage will resume in just scale deflation mode again.
+
+Whether shrinkage is improving or not is dictated by both the number of decision stages needed to build a test case - the fewer, the better, and as a tiebreaker whether the cost is lower in comparison with the previously failing test case.
+
+The cost of a test case is the sum of the contributions from each case factory invocation - each contribution is the square of the difference between the input used to drive the case factory and the maximally shrunk input. Choices are always zero cost, so the cost measures how well the contributions from case factories have been shrunk down to the preferred values.
+
+The aforementioned Fs2 stream is provided by [`.shrinkableCases`](https://raw.githubusercontent.com/sageserpent-open/americium/0f32a19942c3f84fcfebf8f8eecc6c488f1de247/src/main/scala/com/sageserpent/americium/generation/SupplyToSyntaxSkeletalImplementation.scala#L697), this contains the logic for using what is generated by `.cases`, monitoring downstream failed trials and the high-level shrinkage logic. It produces a stream of `TestIntegrationContext` instances, these provide a test case and callbacks that the test code uses via an implicit context set up around the call to the test itself. It is these callbacks that signal to the streaming logic in `shrinkableCases` whether a test case is being rejected due to inline filtration in the test, or whether shrinkage needs to proceed due to a failed trial.
+
+## Wrapping Up
+
+There is a fair bit to cover above, and you will definitely need to poke around the sources to get a full picture - the text is really just a bunch of pointers to important pieces of the puzzle, so you know where to start breaking down the codebase.
+
+One thing that should be apparent - the codebase drifts around from a _high-church_ Scala approach using free monads and streams to a more workaday _just-the-basics pure functional_ Scala to an _imperative Scala-as-a-better-Java_ style to out-an-out usage of _Java sources_. Bear in mind that this is intended as a black-box tool - as long as it passes its tests, and they are rigorous, the code style is of less concern - whatever gets the job done!
+
+Also bear in mind this is as much levelled at the Java community as the Scala community, it just happens to be implemented mostly in Scala because it's ~~cooler and way more fun~~much easier to express the implementation concepts.
+
+In other words, put your efforts more into good testing first and coding style second. Having said that, the codebase has been refactored umpteen times and is definitely ripe for more improvement, so don't hold back if you really need to stir the pot.
+
+If you do decide to hack on the codebase, may I ask that you use the provided Scalaformat setup and stick to it, using auto-formatting. There is also a file for Java formatting using IntelliJ too.
+
+Getting pull requests that are largely format rewrites with a couple of subtle changes hidden within them and no supporting tests will not be expeditious. :grin: If it's any consolation, the auto-formatting isn't my favourite either, but the convenience of not faffing around correcting my lousy typing skills has long triumphed over any attachment I have to any particular code style. Prefer convenience and consistency of pull requests.
+
+Happy hacking!

--- a/gh-pages/docs/wiki-content/from-scalacheck.md
+++ b/gh-pages/docs/wiki-content/from-scalacheck.md
@@ -1,0 +1,112 @@
+---
+layout: default
+title: "Arrived from Scalacheck?"
+parent: Wiki Content
+nav_order: 12
+---
+
+# Arrived from Scalacheck?
+{: .no_toc }
+
+Welcome to Americium - learn the local language
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Come on in and take the weight off your feet, we're friendly here. Like a nice refreshing glass of integrated shrinkage cordial?
+
+If you want to speak Americium it's expected that you'll do so with a Scalacheck accent - here's a guide to translation:
+
+### `Arbitrary` and `Gen`
+
+First off, _there is no `Arbitrary` analogue_. `Gen[+T]` becomes `Trials[+T]`. Easy.
+
+(Actually, there is something called `Factory` specifically for auto-derivation; that is a bit like `Arbitrary`. We'll get to that in a bit...)
+
+### Getting a `Gen`
+
+This is nearly always explicit (we'll cover auto-derivation in a bit).
+
+Instead of using the companion object `Gen`, either import `Trials.api` or use a method defined on the `Trials[T]` instance itself...
+
+* `Gen.choose`, `Gen.chooseNum`, `Gen.chooseChar`, `Gen.chooseBigInt` etc becomes one of `api.integers`, `api.doubles`, `api.characters`, `api.bigInts` etc, using the overloads that take lower and upper bounds.
+* `Gen.double` becomes `api.doubles`, using the overload without any parameters.
+* `Gen.long` becomes `api.longs`, using the overload without any parameters.
+* `Gen.oneOf` becomes either `api.choose` or `api.alternate`, depending on whether you originally fed in `T` or `Gen[T]`.
+* `Gen.const` becomes `api.only`
+* `Gen.delay` becomes `api.delay`
+* `Gen.frequency` becomes `api.chooseWithWeights`
+* `Gen.failed` becomes `api.impossible`
+* `Gen.sequence` becomes `api.sequences`
+* `Gen.option` becomes `<trials instance>.options`
+* `Gen.either` becomes `<trials instance>.or`
+* `Gen.stringOf` becomes `<character trials instance>.several` (Calling `several` on a character trials will build string trials by default.)
+* `Gen.stringOfN` becomes `<character trials instance>.lotsOfSize` (Calling `lotsOfSize` on a character trials will build string trials by default.)
+* `Gen.listOf` becomes `<trials instance>.lists`
+* `Gen.listOfN` becomes `<trials instance>.listsOfSize`
+* `Gen.containerOf` becomes `<trials instance>.several`
+* `Gen.containerOfN` becomes `<trials instance>.lotsOfSize`
+
+**NOTE**: the methods in `TrialsApi` often have names in the plural - so `Gen.double` becomes `api.doubles`, `Gen.sequence` becomes `api.sequences` and so on.
+
+### `Gen` as a monad
+
+`Trials` is a monad too, with a stack-safe implementation. It has a typeclass instance for Cats' `Monad`. So you can `map`, `flatMap`, `filter` and `mapFilter` till you drop. There is even `withFilter` so you can enjoy the full-fat for-comprehension flavour.
+
+### Plugging in test lambdas
+
+Throw away `Prop.forAll` and call `<trials instance>.withLimit(<limit>).supplyTo` instead.
+
+If you have several `Gen` instances, then gang together the corresponding trials with `.and`:
+
+`(<trials one> and <trials two> and <trials three>).withLimit(<limit>).supplyTo`.
+
+### `Test.Parameters`
+
+Substitute for `Test.Parameters.withMinSuccessfulTests` and `Test.Parameters.withMaxDiscardRatio` with `<trials instance>.withStrategy(_ => CasesLimitStrategy.counted(<maximumNumberOfCases>, <maximumStarvationRatio>))`.
+
+Substitute for `Test.Parameters.withInitialSeed` with `<supply-to syntax>.withSeed`, where `<supplyToSyntax>` is `<trials instance>.withLimit(<limit>)` etc.
+
+Substitute for `Test.Parameters.withMaxSize` with `<supply-to syntax>.withComplexityLimit`, where `<supplyToSyntax>` is `<trials instance>.withLimit(<limit>)` etc.
+
+### Sized generators
+
+Substitute `Gen.size` with `api.complexities`. This will reveal the appropriate complexity to your own code that builds up trials. Typically this is done in a flat-map: `api.complexities.flatMap(complexity => <trials expression using the complexity>)`.
+
+### Custom `Shrink` instances
+
+Delete them and dance a jig!
+
+### Scalacheck-Shapeless
+
+Your auto-derivation needs are met by `com.sageserpent.americium.Factory`, which uses the marvellous Magnolia library under the hood.
+
+If you have a case class hierarchy rooted at `Root` and you want `Trials<Root>`, then pull in an implicitly derived instance via:
+
+Scala 2.13
+
+```scala
+implicitly[Factory[Root]].trials
+```
+
+Scala 3
+
+```scala
+given evidence: Factory[Root] = Factory.autoDerived // May need this if `Root` has a recursive definition like, say, `List[T]`.
+
+implicitly[Factory[Root]].trials
+```
+
+As with Scalacheck-Shapeless, you will probably need to supply a few of your own implicit definitions to bootstrap the auto-derivation, it's the same drill only this time it is evidences for various `Factory[T]` instantiations that you need to supply.
+
+As a guide, here are the built-in implicit definitions for [Scala 2.13](https://raw.githubusercontent.com/sageserpent-open/americium/c53549899b4929c1403bad4cb79d3b3e7af75f94/src/main/scala-2.13/com/sageserpent/americium/Factory.scala#L21) and [Scala 3](https://raw.githubusercontent.com/sageserpent-open/americium/c53549899b4929c1403bad4cb79d3b3e7af75f94/src/main/scala-3/com/sageserpent/americium/Factory.scala#L18).
+
+***
+Next topic: [JUnit5 again...]({% link docs/wiki-content/junit5-typed-tests.md %})

--- a/gh-pages/docs/wiki-content/index.md
+++ b/gh-pages/docs/wiki-content/index.md
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Wiki Content
+nav_order: 10
+has_children: true
+permalink: /docs/wiki-content
+---
+
+# Wiki Content
+
+{: .no_toc }
+
+This section contains a direct migration of the original Americium Wiki pages.
+{: .fs-6 .fw-300 }
+
+## Topics
+
+- **[Introducing Americium to your tests]({% link docs/wiki-content/introducing-americium.md %})** - Trials, supplying test cases to tests, shrinkage in action
+- **[Variations in making a trials instance]({% link docs/wiki-content/variations.md %})** - Choices, alternation, special cases
+- **[Building up test cases]({% link docs/wiki-content/building-up-test-cases.md %})** - Collections, mapping, filtering, flat-mapping and recursion
+- **[Multi-parameter tests]({% link docs/wiki-content/multi-parameter-tests.md %})** - Supplying independently varying test cases to a trial
+- **[Reproducing a failing test case quickly]({% link docs/wiki-content/reproducing-failures.md %})** - Recipes and recipe hashes
+- **[All about shrinkage]({% link docs/wiki-content/shrinkage.md %})** - What it means and how it is achieved
+- **[Configuration buttons, dials and levers]({% link docs/wiki-content/configuration.md %})** - Case limit strategies, seeding, complexity, controlling shrinking
+- **[Awkward tests]({% link docs/wiki-content/awkward-tests.md %})** - Sometimes the test doesn't even want to run itself
+- **[JUnit5 Integration]({% link docs/wiki-content/junit5-integration.md %})** - Going with the flow
+- **[Techniques]({% link docs/wiki-content/techniques.md %})** - Impress your friends with sleights of hand
+- **[The competition]({% link docs/wiki-content/competition.md %})** - Oh, that bunch?
+- **[Arrived from Scalacheck?]({% link docs/wiki-content/from-scalacheck.md %})** - Welcome to Americium - learn the local language
+- **[JUnit5 again]({% link docs/wiki-content/junit5-typed-tests.md %})** - Strongly typed test supply
+- **[Design and Implementation]({% link docs/wiki-content/design-and-implementation.md %})** - Yes, do pay attention to the man behind the curtain
+- **[How did this come about?]({% link docs/wiki-content/background.md %})** - Sit down and let me tell you...
+
+---
+
+## Navigation
+
+You can follow the topics in the order presented above or in the sidebar, which follows the original Wiki structure.

--- a/gh-pages/docs/wiki-content/introducing-americium.md
+++ b/gh-pages/docs/wiki-content/introducing-americium.md
@@ -1,0 +1,218 @@
+---
+layout: default
+title: "Introducing Americium to your tests"
+parent: Wiki Content
+nav_order: 1
+---
+
+# Introducing Americium to your tests
+{: .no_toc }
+
+Trials, supplying test cases to tests, shrinkage in action
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Americium's API is built around the `Trials<Case>` generic interface. A trials instance supplies test case data fed to a test that takes a single test case as a parameter; the test repeatedly carries out a _trial_ of whatever it tests using varying test cases.
+
+We say that a trials instance _supplies_ test cases to a parameterised test, each execution of the test being a trial. The type parameter of `Trials` is the type of the supplied test cases. Loosely speaking, we can think of `Trials` as being some kind of fountain of test data to start with - but as the name suggests, there is a notion of a test failing or succeeding that is important - we'll come back to this in a bit...
+
+Let's see a simple example in JShell:-
+
+```java
+import com.sageserpent.americium.java.Trials;
+
+final Trials<Integer> trials = Trials.api().integers(-5, 5);
+
+trials.withLimit(10).supplyTo(System.out::println);
+```
+
+We always start with an API object that for Java folk is accessed via a static method in `com.sageserpent.americium.java.Trials` and for Scala folk is accessed via a method in the companion object for `com.sageserpent.americium.Trials` (note that the Scala flavour is the default in the package namespace, Java has to be called out explicitly).
+
+The API objects both have a swathe of methods for getting a trials instance - we use `.integers` and supply lower and upper bounds to the test cases to supply.
+
+Here, we've used `System.out::println` as our parameterised test. Unless our test cases have a very poor implementation of `.toString`, it is unlikely that this 'test' can fail, but it is instructive to see the output:
+
+```
+2
+-5
+5
+4
+1
+-4
+0
+-3
+-2
+-1
+```
+
+So we asked for a `Trials<Integer>` to supply a range of integer test cases between -5 and 5, and it did that. Huzzah!
+
+Looking closely, we note that there is no repetition in the supplied cases, and that one case is missing - the number 3. Now, we asked for a limit of at most 10 cases, and there are 11 integers between -5 and 5 inclusive, so that makes sense.
+
+We always have to control the number of trials performed, and this is what `.withLimit` is for. For example:
+
+```java
+final Trials<Integer> trials = Trials.api().integers();
+
+
+trials.withLimit(20).supplyTo(System.out::println);
+```
+
+That overload of `.integers` uses a default range spanning the entire domain of integer values, so this combination will churn out:
+
+```
+797772800
+-1955330156
+2128104420
+1531869968
+637157859
+1806495736
+279436637
+1987104774
+-1865757019
+633033882
+1503300339
+203172046
+273004927
+-1111845053
+-1367005977
+-1209513608
+342249173
+-685852310
+-832980694
+-1545019583
+```
+
+There are a lot of integers, so we need the limit to tell Americium that we're happy that it has tested enough or else it would have to slog through all 2^32 values. In fact, we cannot avoid the limit - the `.supplyTo` method belongs to another generic interface `SupplyToSyntax<Case>`, and we get that via the bridging call to `.withLimit`, so we're sure some limit is enforced.
+
+Let's make the test more exciting:
+
+```java
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+final Trials<Integer> trials = Trials.api().integers();
+
+trials.withLimit(1000).supplyTo(x -> {
+    final int xSquared = x * x;
+
+    assertThat(xSquared / x, equalTo(x));
+});
+```
+
+What happens? We see a test failure:
+
+```
+java.lang.AssertionError:
+Expected: <-46367>
+     but: was <46262>
+```
+
+Clearly there has been arithmetic overflow and thus wraparound when the test case was squared. Let's modify that test a little to peek at what's going on...
+
+```java
+trials.withLimit(1000).supplyTo(x -> {
+    final int xSquared = x * x;
+
+    try {
+        assertThat(xSquared / x, equalTo(x));
+    } catch (Throwable e) {
+        System.out.println(e);
+        throw e;
+    }
+});
+```
+
+Now we see this:
+
+```
+java.lang.AssertionError:
+Expected: <797772800>
+     but: was <1>
+java.lang.AssertionError:
+Expected: <637157859>
+     but: was <2>
+java.lang.AssertionError:
+Expected: <179318108>
+     but: was <-9>
+java.lang.AssertionError:
+Expected: <83665336>
+     but: was <-23>
+java.lang.AssertionError:
+Expected: <72142783>
+     but: was <-1>
+java.lang.AssertionError:
+Expected: <58037089>
+     but: was <23>
+java.lang.AssertionError:
+Expected: <9360959>
+     but: was <174>
+java.lang.AssertionError:
+Expected: <8098142>
+     but: was <5>
+java.lang.AssertionError:
+Expected: <7867278>
+     but: was <-90>
+java.lang.AssertionError:
+Expected: <7611507>
+     but: was <29>
+java.lang.AssertionError:
+Expected: <1873786>
+     but: was <1113>
+java.lang.AssertionError:
+Expected: <1002214>
+     but: was <-588>
+java.lang.AssertionError:
+Expected: <890081>
+     but: was <2213>
+java.lang.AssertionError:
+Expected: <480682>
+     but: was <-1816>
+java.lang.AssertionError:
+Expected: <252673>
+     but: was <-2298>
+java.lang.AssertionError:
+Expected: <-142617>
+     but: was <7959>
+java.lang.AssertionError:
+Expected: <99081>
+     but: was <12384>
+java.lang.AssertionError:
+Expected: <-49681>
+     but: was <36769>
+java.lang.AssertionError:
+Expected: <-48964>
+     but: was <38752>
+java.lang.AssertionError:
+Expected: <-46976>
+     but: was <44452>
+java.lang.AssertionError:
+Expected: <46686>
+     but: was <-45310>
+java.lang.AssertionError:
+Expected: <-46367>
+     but: was <46262>
+```
+
+Americium notices the very first failing trial, where a whopping 797772800 was squared, then goes into _shrinkage_ mode, where it tries to maximise the shrinkage of the test case that causes the test to fail, resulting in the test case of -46367 that we saw earlier. While it is shrinking, it intercepts the exceptions thrown by the test and keeps going; once it has settled on a final failing test case, it propagates the exception out of the call to `.supplyTo`, so by default, you will see the _maximally shrunk_ test case.
+
+The reason for using phrase 'maximally shrunk' and not just plain 'minimised' is that there is no guarantee that the test case is truly a minimum - there may be values that are even more shrunk, nor have we have discussed what we would mean by minimum yet - in this case the values **oscillated** as shrinkage increased, switching back and forth from positive to negative.
+
+Doing some trial and error manual testing yields the best shrinkage of -46341. If we increase the limit in the test above from 1000 to 1500, we will find that Americium roots out the best value of -46341, but even so, that first maximally shrunk case of -46367 wasn't bad. In fact, Americium can shrink down to -47445 if run with a miserly limit of 10 trials.
+
+The moral of the story is, if you want to get good shrinkage of your failing test case, give Americium a high enough limit - experiment with it.
+
+The eagle-eyed will observe that more test cases can be supplied to the test than the limit if a failure is observed. We'll get to that in the section about configuration, but for now, the rule is simply that as long as the trials all succeed, Americium will not supply more test cases than the limit.
+
+To summarise, we're seen how to get a trials of integers, how to supply test cases from it to a test, and what happens when a test trial fails. Great. Now take a look at `TrialsApi` in your preferred language API flavour and note the plethora of convenience methods for building trials of integers, longs, big integers, doubles, big decimals, bytes, characters, strings, Booleans and instants. Some are overloaded to take ranges, and some have a mysterious _shrinkage target_ too - we'll talk about that when we revisit shrinkage in a later topic.
+
+***
+Next topic: [Variations in making a trials instance...]({% link docs/wiki-content/variations.md %})

--- a/gh-pages/docs/wiki-content/junit5-integration.md
+++ b/gh-pages/docs/wiki-content/junit5-integration.md
@@ -1,0 +1,226 @@
+---
+layout: default
+title: "JUnit5 Integration"
+parent: Wiki Content
+nav_order: 9
+---
+
+# JUnit5 Integration
+{: .no_toc }
+
+Going with the flow
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Americium takes a lean and mean approach; other than supplying test cases and shrinking them down, it doesn't have much to say about how we want to structure tests, what kind of assertion language to use, the best approach to sharing tests between implementations, setup and teardown and so forth.
+
+However, JUnit is commonly used in Java development, and it is likely that your favourite IDE sports some kind of integration with it. In the JUnit5 incarnation, there is a nice `@ParameterizedTest` annotation that allows a test taking one or more parameters to be run several times against varying actual arguments. Sounds familiar?
+
+Now, the support for parameterised testing in JUnit5 out of the box is nice, but rudimentary - either we have to supply the test cases by hand as an explicit list in code or a file, or generate them in some arbitrary manner that JUnit5 does not help with. There is no concept of test case shrinkage either - the individual tests either pass or fail, and that's it.
+
+It does generalise test setup and teardown to work with each test run, and it looks cool though to see lots of test runs in IntelliJ...
+
+Not to be outdone, Americium offers an _optional_ integration with JUnit5 that expresses the trials framework in a similar fashion to `@ParameterizedTest` - this includes the support for generalising setup and teardown and the funky IDE integration.
+
+> **Artifact Required:** The JUnit5 integration features described on this page are provided by the separate `americium-junit5` artifact (since version 1.26.0). Add this dependency to your project:
+> ```scala
+> libraryDependencies += "com.sageserpent" %% "americium-junit5" % "x.y.z"
+> ```
+
+> **Package Information**
+>
+> **Java users:** Import from `com.sageserpent.americium.junit5`
+> ```java
+> import com.sageserpent.americium.junit5.TrialsTest;
+> import com.sageserpent.americium.junit5.ConfiguredTrialsTest;
+> ```
+>
+> **Scala users:** Import from `com.sageserpent.americium.junit5`
+> ```scala
+> import com.sageserpent.americium.junit5.*
+> ```
+
+## @TrialsTest
+
+Remember the `Tiers` example? Let's integrate this with JUnit5:
+
+```java
+import com.sageserpent.americium.junit5.TrialsTest;
+
+public class TiersTest {
+    private final static Trials<ImmutableList<Integer>> queryValueLists = api()
+            .integers(-1000, 1000)
+            .immutableLists()
+            .filter(list -> !list.isEmpty());
+
+
+    private final static Trials<Tuple2<ImmutableList<Integer>,
+            ImmutableList<Integer>>>
+            testCases =
+            queryValueLists.flatMap(queryValues -> {
+                final int minimumQueryValue =
+                        queryValues.stream().min(Integer::compareTo).get();
+
+                // A background is a (possibly empty) run of values that are
+                // all less than the query values.
+                final Trials<ImmutableList<Integer>> backgrounds = api()
+                        .integers(Integer.MIN_VALUE, minimumQueryValue - 1)
+                        .immutableLists();
+
+                // A section is either a query value in a singleton list, or
+                // a background.
+                final List<Trials<ImmutableList<Integer>>> sectionTrials =
+                        queryValues
+                                .stream()
+                                .flatMap(queryValue ->
+                                                 Stream.of(api().only(
+                                                                   ImmutableList.of(
+                                                                           queryValue)),
+                                                           backgrounds))
+                                .collect(Collectors.toList());
+
+                sectionTrials.add(0, backgrounds);
+
+                // Glue the trials together and flatten the sections they
+                // yield into a single feed sequence per trial.
+                final Trials<ImmutableList<Integer>> feedSequences =
+                        api().immutableLists(sectionTrials).map(sections -> {
+                            final ImmutableList.Builder<Integer> builder =
+                                    ImmutableList.builder();
+                            sections.forEach(builder::addAll);
+                            return builder.build();
+                        });
+                return feedSequences.map(feedSequence -> Tuple.tuple(queryValues,
+                                                                     feedSequence));
+            });
+
+    @TrialsTest(trials = "testCases", casesLimit = 10)
+    void tiersShouldRetainTheLargestElements(Tuple2<ImmutableList<Integer>,
+            ImmutableList<Integer>> testCase) {
+        final ImmutableList<Integer> queryValues = testCase._1();
+        final ImmutableList<Integer> feedSequence = testCase._2();
+
+        System.out.format("Query values: %s, feed sequence: %s\n",
+                          queryValues,
+                          feedSequence);
+
+        final int worstTier = queryValues.size();
+
+        final Tiers<Integer> tiers = new Tiers<>(worstTier);
+
+        feedSequence.forEach(tiers::add);
+
+        final ImmutableList.Builder<Integer> builder =
+                ImmutableList.builder();
+
+        int tier = worstTier;
+
+        int previousTierOccupant = Integer.MIN_VALUE;
+
+        do {
+            final Integer tierOccupant = tiers.at(tier).get();
+
+            assertThat(tierOccupant,
+                       greaterThanOrEqualTo(previousTierOccupant));
+
+            builder.add(tierOccupant);
+
+            previousTierOccupant = tierOccupant;
+        } while (1 < tier--);
+
+        final ImmutableList<Integer> arrangedByRank = builder.build();
+
+        assertThat(arrangedByRank,
+                   containsInAnyOrder(queryValues.toArray()));
+    }
+}
+```
+
+We've decanted the trials instances into the test class, `TiersTest` as final static fields - they are immutable, so that fits nicely. The test code itself goes into a method that looks a lot like a test annotated with `@TrialsTest` instead of the usual `@Test` that ships with JUnit5:
+
+```java
+@TrialsTest(trials = "testCases", casesLimit = 10)
+    void tiersShouldRetainTheLargestElements(Tuple2<ImmutableList<Integer>,
+            ImmutableList<Integer>> testCase) .....
+```
+
+If you've used `@ParameterisedTest` before, this should seem familiar - note that Americium's integration is simpler; `@ParameterisedTest` needs a supporting `@ValueSource` / `@MethodSource` or something similar to set up the injection of test cases, whereas `@TrialsTest` does it all in one place.
+
+The annotation parameters `trials` names the static field that has the trials instance used to supply the test cases; this is analogous to `@MethodSource`'s `value` parameter. The parameter `casesLimit` does the same thing as `.withLimit`, and there are parameters `complexity` and `shrinkageAttempts` too, if you need them.
+
+The results shown by IntelliJ are: ![](https://raw.githubusercontent.com/sageserpent-open/americium/4ced3f413c91ffee5e5587f48f137593cae03d93/screenshots/TiersInJUnit5.png)
+
+That's nice - we can see each trial's run, the test case passed to each trial and the output from each trial. Other IDEs have similar support for JUnit5. We can execute an individual trial in IntelliJ by right clicking on a trial, check your own favourite IDE for similar functionality.
+
+Picking apart the `Tuple2` looks a bit hokey - it turns out we can do better here:
+
+```java
+    @TrialsTest(trials = "testCases", casesLimit = 10)
+    void tiersShouldRetainTheLargestElements(ImmutableList<Integer> queryValues,
+                                             ImmutableList<Integer> feedSequence) {
+        System.out.format("Query values: %s, feed sequence: %s\n",
+                          queryValues,
+                          feedSequence);
+
+...
+```
+
+The integration matches the two arguments with a tupled test case and unpicks it for us prior to running the trial. This approach can be mixed and matched, where tupled and non-tupled trials can be ganged together with `.and` and unpicked into multiple arguments. When multiple trials are ganged together, it is possible to unpick individual tuples into clumps of arguments or leave them as tuple arguments according to preference.
+
+What happens if we use `@BeforeEach` and `@AfterEach` to annotate setup and teardown methods, respectively? The integration will execute test setup before each trial and teardown after each trial - so each trial gets its own clean environment to run in. `@BeforeAll` and `@AfterAll` run prior to all tests in the test suite, be they annotated with `@Test`, `@ParameterizedTest` or `@TrialsTest`.
+
+By default JUnit5 uses per-method test lifecycle for its tests. This mandates that the trials instance named by `@TrialsTest` needs to be _static_, as should the setup and teardown methods annotated with `@BeforeEach` and `@AfterEach`. If we wanted to use non-static definitions, then the test lifecycle would need to be per-class - use `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` on the test class.
+
+## Shrinkage
+
+Let's revisit the test for `PoorQualitySetMembershipPredicate`:
+
+```java
+public class SetMembershipPredicateTest {
+    private final static Trials<ImmutableList<Long>> lists =
+            Trials.api().longs().immutableLists();
+
+    private final static Trials<Long> longs = Trials.api().longs();
+
+    @TrialsTest(trials = {"lists", "longs", "lists"}, casesLimit = 10)
+    void setMembershipShouldBeRecognisedByThePredicate(
+            ImmutableList<Long> leftHandList, long additionalLongToSearchFor,
+            ImmutableList<Long> rightHandList) {
+        final Predicate<Long> systemUnderTest =
+                new PoorQualitySetMembershipPredicate(ImmutableList
+                                                              .builder()
+                                                              .addAll(leftHandList)
+                                                              .add(additionalLongToSearchFor)
+                                                              .addAll(rightHandList)
+                                                              .build());
+
+        assertThat(systemUnderTest.test(additionalLongToSearchFor),
+                   is(true));
+    }
+}
+```
+
+Observe how we ganged together the three trials directly in the `@TrialsTest` annotation, so they can be unpicked directly into the test.
+
+Running it reveals trial failures: ![](https://raw.githubusercontent.com/sageserpent-open/americium/4ced3f413c91ffee5e5587f48f137593cae03d93/screenshots/SetMembershipPredicateTest.png)
+
+The second trial failed, then Americium went into shrinkage mode, which is made evident in the test case display. ~~It is important to highlight shrinkage mode, as trying to right click on a trial run as part of shrinkage will in general **not** manage to run its test case again; only trials run up to and including the first failure can be directly re-run from the IDE, this is a quirk of how JUnit5 works under the hood.~~ (*Since release 1.18.0 you can now directly replay a trial run that was done as part of shrinkage.*)
+
+We also see the final test failure with the maximally shrunk case and a way of reproducing it. The use of the Java properties `trials.recipeHash` and `trials.recipe` works with the JUnit5 integration in the same way as in standalone mode.
+
+## @ConfiguredTrialsTest
+
+For more flexibility in configuration, there is another test annotation, `@ConfiguredTrialsTest` that works with instances of `SupplyToSyntax` instead of `Trials`. Its use is pretty much the same as for `@TrialsTest`, only you use `.withStrategy` etc to configure your `SupplyToSyntax` instance to be just so.
+
+You can only refer to one instance of `SupplyToSyntax`, so if you want to use multiple trials, gang them together first with `.and` and then call `.withStrategy` or `withLimit`.
+
+***
+Next topic: [Techniques...]({% link docs/wiki-content/techniques.md %})

--- a/gh-pages/docs/wiki-content/junit5-typed-tests.md
+++ b/gh-pages/docs/wiki-content/junit5-typed-tests.md
@@ -1,0 +1,118 @@
+---
+layout: default
+title: "JUnit5 again"
+parent: Wiki Content
+nav_order: 13
+---
+
+# JUnit5 again
+{: .no_toc }
+
+Strongly typed test supply
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+The JUnit5 integration discussed before is great if you're used to JUnit5's `@ParameterizedTest` annotation, but if you've used Scalacheck, you may be a little put off by the _stringly_ typed code that has is forced on us by Java annotations - to wire up the supplier of test cases, we have to specify the *name* of a field in the test class.
+
+Who knows what actual test cases might be supplied, or even if the field has been renamed in the meantime? Sure, we'll see a runtime error with some diagnostic, but...
+
+Fear not - whether you are writing tests in Java or Scala, it is possible to integrate with JUnit5 with strongly-typed coupling between the test case supply and the actual parameterised test. So the supplier of test cases has to supply test cases whose type and number match the types and number of the arguments to the parameterised test, and this will be checked at compile time.
+
+Yes, I wrote _JUnit5_ and _Scala_ in the same sentence; it is feasible to use JUnit5 directly with Scala test and system-under-test code using the Scala flavour of the `Trials` API. You are free to pull in whatever assertion library works with JUnit5 and Scala - I've been experimenting with [Expecty](https://github.com/eed3si9n/expecty), so far it works very nicely as the primary assertion language, using JUnit5's `assertThrows` to check that an exception is thrown.
+
+What does this look like? Let's cutover the permutations example from before:
+
+```scala
+// Junit5...
+import org.junit.jupiter.api.TestFactory
+// Integration with JUnit5...
+import com.sageserpent.americium.junit5.*
+// Expecty assertions...
+import com.eed3si9n.expecty.Expecty.assert
+
+```
+
+```scala
+class DemonstrateJUnit5Integration {
+  @TestFactory
+  def thingsShouldBeInOrder(): DynamicTests = {
+    val permutations: Trials[SortedMap[Int, Int]] =
+      api.only(15).flatMap { size =>
+        val sourceCollection = 0 until size
+
+        api
+          .indexPermutations(size)
+          .map(indices => {
+            val permutation = SortedMap.from(indices.zip(sourceCollection))
+
+            assume(permutation.size == size)
+
+            assume(SortedSet.from(permutation.values).toSeq == sourceCollection)
+
+            permutation
+          })
+      }
+
+      permutations
+        .withLimit(15)
+        .dynamicTests { permuted =>
+          Trials.whenever(permuted.nonEmpty) {
+            assert(permuted.values zip permuted.values.tail forall {
+              case (left, right) =>
+                left <= right
+            })
+          }
+        }
+  }
+}
+```
+
+What's changed? For one thing, we have a test method that is decorated with JUnit5's `@TestFactory` annotation, this expects the method to yield some kind of Java abstraction of a series of `DynamicTest` instances. To avoid having to pollute your nice Scala test code with the names of coarse and ill-mannered Java types, there is a Scala type alias `DynamicTests` (note the plural) that is pulled in from the `import com.sageserpent.americium.junit5.*` import.
+
+The rest of the code looks much the same - only instead of a call to `supplyTo` we see a call to `dynamicTests`, also pulled in via that import. This packages up our parameterised test and supply into something that JUnit5 can use, the rub being that we have used a type-checked call to connect the supplier and the parameterised test.
+
+Those eagle-eyed readers will note the use of an assertion - this is pulled in by `import com.eed3si9n.expecty.Expecty.assert`, although the standard `Predef.assert` would also do. Try both out and see the difference!
+
+The method `dynamicTests` is overloaded so that trials instances can be ganged together to supply multi-argument parameterised tests. This technique also works with trials whose test cases are tuple types too.
+
+Note that the `Trials` instance in the example is the _Scala_ form, even though we are using JUnit5.
+
+Java folk have not been neglected: there is a module class `com.sageserpent.americium.junit5.java.JUnit5` that provides a similar experience, only this time we do use the _Java_ form of `Trials`. Here's an example taken from the Javadoc for `JUnit5.dynamicTests`:
+
+```java
+
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.DynamicTest;
+import com.sageserpent.americium.junit5.java.JUnit5;
+import java.util.Iterator;
+
+class DemonstrateJUnit5Integration{
+     @TestFactory
+     Iterator<DynamicTest> dynamicTestsExample() {
+         final TrialsScaffolding.SupplyToSyntax<Integer> supplier =
+                 Trials.api().integers().withLimit(10);
+
+         return JUnit5.dynamicTests(
+                 supplier,
+                 // The parameterised test: it just prints out the test case...
+                 testCase -> {
+                     System.out.format("Test case %d\n", testCase);
+                 });
+     }
+}
+```
+
+This time we can't use the Scala type alias so we see `Iterator<DynamicTest>` in all of its glory, and revel in it because Scala developers are just namby-pamby purists anyway.
+
+Again, there are overloads of `JUnit5.dynamicTests`, and these work both with ganged trials and trials of tuples.
+
+***
+Next topic: [Design and Implementation...]({% link docs/wiki-content/design-and-implementation.md %})

--- a/gh-pages/docs/wiki-content/multi-parameter-tests.md
+++ b/gh-pages/docs/wiki-content/multi-parameter-tests.md
@@ -1,0 +1,107 @@
+---
+layout: default
+title: "Multi-parameter tests"
+parent: Wiki Content
+nav_order: 4
+---
+
+# Multi-parameter tests
+{: .no_toc }
+
+Supplying independently varying test cases to a trial
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Consider this wondrous artefact:
+
+```java
+class PoorQualitySetMembershipPredicate<Element extends Comparable<Element>> implements Predicate<Element> {
+    private final Comparable[] elements;
+
+    public PoorQualitySetMembershipPredicate(Collection<Element> elements) {
+        this.elements = elements.toArray(Comparable[]::new);
+    }
+
+    @Override
+    public boolean test(Element element) {
+        return 0 <= Arrays.binarySearch(elements, element);
+    }
+}
+```
+
+Let's test it:
+
+```java
+final Trials<ImmutableList<Long>> lists =
+        Trials.api().longs().immutableLists();
+
+final Trials<Long> longs = Trials.api().longs();
+
+lists
+        .and(longs)
+        .and(lists)
+        .withLimit(10)
+        .supplyTo((leftHandList, additionalLongToSearchFor,
+                   rightHandList) -> {
+            final Predicate<Long> systemUnderTest =
+                    new PoorQualitySetMembershipPredicate(ImmutableList
+                                                                  .builder()
+                                                                  .addAll(leftHandList)
+                                                                  .add(additionalLongToSearchFor)
+                                                                  .addAll(rightHandList)
+                                                                  .build());
+
+            assertThat(systemUnderTest.test(additionalLongToSearchFor),
+                       is(true));
+        });
+```
+
+What we're doing here is to supply our test with a test case that is divided into three independently varying inputs - we have a left hand list of integers, a long value that we expect to find and a right hand list of integers. We surround the value we want to find by the two lists, and as these lists vary, so will the system under test - sometimes one or both of these will be empty, so we cover the cases where we are searching for a leading, trailing or singleton element too.
+
+To supply the three inputs, we take three trials instances and gang them together using the `.and` combinator method - this builds a specialised form of a trials object that has custom overloads of `.supplyTo` for tests that either take the corresponding number of arguments, or a single tuple that has the arguments as components.
+
+You may have spotted that `lists` occurs in two places in the gang - so does this mean that the parameters `leftHandList` and `rightHandList` will be the same for every trial? **No** - Americium does not treat trials instances as canned sequences of values, rather as specifications for what kind of values are produced. So when a trial is run, Americium is free to vary the first and third inputs _independently_ of each other: they will produce the same kind of data, namely lists of long values, but in general those values will not coincide in a given trial - although they might every now and then.
+
+Currently up to four elementary trials can be ganged together via `.and`.
+
+What happens when we run the test?
+
+```
+java.lang.AssertionError:
+Expected: is <true>
+     but: was <false>
+Case:
+[[1],0,[]]
+```
+
+Ah yes - we didn't sort the contents of the array `PoorQualitySetMembershipPredicate.elements` in the constructor, so the subsequent binary search will only work if the elements are already sorted. Let's fix it:
+
+```java
+class AwesomeSetMembershipPredicate<Element extends Comparable<Element>> implements Predicate<Element> {
+    private final Comparable[] elements;
+
+    public AwesomeSetMembershipPredicate(Collection<Element> elements) {
+        this.elements = elements.toArray(Comparable[]::new);
+
+        Arrays.sort(this.elements, Comparator.naturalOrder());
+    }
+
+    @Override
+    public boolean test(Element element) {
+        return 0 <= Arrays.binarySearch(elements, element);
+    }
+}
+```
+
+That passes the test nicely.
+
+***
+Next topic: [Reproducing a failing test case quickly...]({% link docs/wiki-content/reproducing-failures.md %})

--- a/gh-pages/docs/wiki-content/reproducing-failures.md
+++ b/gh-pages/docs/wiki-content/reproducing-failures.md
@@ -1,0 +1,268 @@
+---
+layout: default
+title: "Reproducing a failing test case quickly"
+parent: Wiki Content
+nav_order: 5
+---
+
+# Reproducing a failing test case quickly
+{: .no_toc }
+
+Recipes and recipe hashes
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Here's a tricky bit of implementation:
+
+```java
+class Tiers<Element extends Comparable<Element>> {
+    final int worstTier;
+
+    final List<Element> storage;
+
+    public Tiers(int worstTier) {
+        this.worstTier = worstTier;
+        storage = new ArrayList<>(worstTier) {
+            @Override
+            public void add(int index, Element element) {
+                if (size() < worstTier) {
+                    super.add(index, element);
+                } else {
+                    for (int shiftDestination = 0;
+                         shiftDestination < index; ++shiftDestination) {
+                        super.set(shiftDestination,
+                                  super.get(1 + shiftDestination));
+                    }
+
+                    super.set(index, element);
+                }
+            }
+        };
+    }
+
+    void add(Element element) {
+        final int index = Collections.binarySearch(storage, element);
+
+        if (0 > index) {
+            storage.add(-(index + 1), element);
+        } else {
+            storage.add(index, element);
+        }
+    }
+
+    Optional<Element> at(int tier) {
+        return 0 < tier && tier <= storage.size()
+               ? Optional.of(storage.get(storage.size() - tier))
+               :
+               Optional.empty();
+    }
+}
+```
+
+The purpose of `Tiers` is to take a series of elements, and arrange the elements by tier, where tier 1 is the highest element, tier 2 is the next highest and so on down to a fixed worst tier. Elements that don't make the grade (or are surpassed later) are summarily ejected.
+
+Testing this is quite involved and allows a demonstration of a realistic property-based test. There is a lot of code to follow, but the gist of it is to start with a list of query values that we expect the tiers instance to end up with, then present them in a feed sequence to the tiers instance, surrounding each query value with a run of background values that are constructed to be less than all of the query values.
+
+This approach explores the full range of possibilities - we may have duplicates in the query values (so presumably they should occupy adjacent tiers). Query values may be interspersed with empty lists, in which case they can start or end the feed sequence, or come in adjacent clumps. The query values aren't presented in any particular order, nor are the background values. All we can say is that because the query values are the highest by construction, then as long as we set the number of tiers to be the number of query values, then they should all make it through to the final assessment.
+
+So, on with the test:
+
+```java
+final Trials<ImmutableList<Integer>> queryValueLists = api()
+        .integers(-1000, 1000)
+        .immutableLists()
+        .filter(list -> !list.isEmpty());
+
+
+final Trials<Tuple2<ImmutableList<Integer>, ImmutableList<Integer>>>
+        testCases =
+        queryValueLists.flatMap(queryValues -> {
+            final int minimumQueryValue =
+                    queryValues.stream().min(Integer::compareTo).get();
+
+            // A background is a (possibly empty) run of values that are
+            // all less than the query values.
+            final Trials<ImmutableList<Integer>> backgrounds = api()
+                    .integers(Integer.MIN_VALUE, minimumQueryValue - 1)
+                    .immutableLists();
+
+            // A section is either a query value in a singleton list, or
+            // a background.
+            final List<Trials<ImmutableList<Integer>>> sectionTrials =
+                    queryValues
+                            .stream()
+                            .flatMap(queryValue ->
+                                             Stream.of(api().only(
+                                                               ImmutableList.of(
+                                                                       queryValue)),
+                                                       backgrounds))
+                            .collect(Collectors.toList());
+
+            sectionTrials.add(0, backgrounds);
+
+            // Glue the trials together and flatten the sections they
+            // yield into a single feed sequence per trial.
+            final Trials<ImmutableList<Integer>> feedSequences =
+                    api().immutableLists(sectionTrials).map(sections -> {
+                        final ImmutableList.Builder<Integer> builder =
+                                ImmutableList.builder();
+                        sections.forEach(builder::addAll);
+                        return builder.build();
+                    });
+            return feedSequences.map(feedSequence -> Tuple.tuple(queryValues,
+                                                                 feedSequence));
+        });
+
+try {
+    testCases.withLimit(40).supplyTo(testCase -> {
+        final ImmutableList<Integer> queryValues = testCase._1();
+        final ImmutableList<Integer> feedSequence = testCase._2();
+
+        final int worstTier = queryValues.size();
+
+        final Tiers<Integer> tiers = new Tiers<>(worstTier);
+
+        feedSequence.forEach(tiers::add);
+
+        final ImmutableList.Builder<Integer> builder =
+                ImmutableList.<Integer>builder();
+
+        int tier = worstTier;
+
+        int previousTierOccupant = Integer.MIN_VALUE;
+
+        do {
+            final Integer tierOccupant = tiers.at(tier).get();
+
+            assertThat(tierOccupant, greaterThanOrEqualTo(previousTierOccupant));
+
+            builder.add(tierOccupant);
+
+            previousTierOccupant = tierOccupant;
+        } while (1 < tier--);
+
+        final ImmutableList<Integer> arrangedByRank = builder.build();
+
+        assertThat(arrangedByRank, containsInAnyOrder(queryValues.toArray()));
+    });
+} catch (TrialsFactoring.TrialException e) {
+    System.out.println(e);
+}
+```
+
+By now, we won't be surprised to find that it doesn't work:
+
+```
+Trial exception with underlying cause:
+java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
+Case:
+[[0],[-1, 0]]
+Reproduce via Java property:
+trials.recipeHash=b91fa06969da28bd58ca711b7b50ff75
+Reproduce via Java property:
+trials.recipe="[{\"ChoiceOf\":{\"index\":1}},{\"FactoryInputOf\":{\"input\":0}},{\"ChoiceOf\":{\"index\":0}},{\"ChoiceOf\":{\"index\":1}},{\"FactoryInputOf\":{\"input\":-1}},{\"ChoiceOf\":{\"index\":0}},{\"ChoiceOf\":{\"index\":0}}]"
+```
+
+That failing test case looks nice and shrunk - so how do we debug this? We really don't want to sit in the debugger ploughing through all the initial test failures (there are plenty of them), not to mention all the other trials that succeeded before we start analysing the final maximally shrunk test case's trial - we just want to run a single trial for that maximally shrunk case straightaway and get to debugging _that_.
+
+The exception from Americium (it's a `TrialsFactoring.TrialException` that wraps up the exception thrown by the test) tells us how - we re-execute our test with a JVM property setting of:
+```
+-Dtrials.recipeHash=b91fa06969da28bd58ca711b7b50ff75
+```
+
+This will force Americium to go directly to the trial we're interested in, and we can get debugging. Of course, this only works if we run the _same test_ as when the recipe hash was generated. Other tests with different trials won't understand the recipe hash and will likely fault.
+
+Once we're done fixing the problem, we remove the property setting and Americium goes back to its usual behaviour of exploring lots of trials. We can keep on repeating the same test case by leaving the property set.
+
+It is possible to work with several different failing tests at the same time, each with their own recipe hash.
+
+The way this works is that Americium records a _recipe_ and its recipe hash in a database located in a temporary folder somewhere in the filesystem. If we want to specify where, we set the JVM property `java.io.tmpdir`. The database name is given by `trials.runDatabase`. These properties are found in `JavaPropertyNames`, but if we don't specify them, defaults will be chosen.
+
+Now, because the reproduction of the trials is driven by the recipe (the recipe hash is simply used as a key to retrieve it), then if say we observe a test failure in a CI box, the recipe hash is of no use to us - our local computer will have its own database that knows nothing about that. To debug the failure, we turn to the related property, `trials.recipe`, which is escaped JSON that can be passed to a test run as a Java property either from the command line or embedded in a shell script or equivalent.
+
+```
+-Dtrials.recipe="[{\"ChoiceOf\":{\"index\":1}},{\"FactoryInputOf\":{\"input\":0}},{\"ChoiceOf\":{\"index\":0}},{\"ChoiceOf\":{\"index\":1}},{\"FactoryInputOf\":{\"input\":-1}},{\"ChoiceOf\":{\"index\":0}},{\"ChoiceOf\":{\"index\":0}}]"
+```
+
+This approach always works, but recipe hashes are nice and compact if you are working with locally running tests to start with.
+
+Where did we go wrong? Ah yes - sometimes an element just drops immediately off the lowest tier as it is added; our element shifting logic is off-by-one, as well the actual pseudo-insertion when all tiers are filled. The fixed version looks like this:
+
+```java
+class Tiers<Element extends Comparable<Element>> {
+    final int worstTier;
+
+    final List<Element> storage;
+
+    public Tiers(int worstTier) {
+        this.worstTier = worstTier;
+        storage = new ArrayList<>(worstTier) {
+            @Override
+            public void add(int index, Element element) {
+                if (size() < worstTier) {
+                    super.add(index, element);
+                } else if (0 < index) {
+                    for (int shiftDestination = 0;
+                         shiftDestination < index - 1; ++shiftDestination) {
+                        super.set(shiftDestination,
+                                  super.get(1 + shiftDestination));
+                    }
+
+                    super.set(index - 1, element);
+                }
+            }
+        };
+    }
+
+    void add(Element element) {
+        final int index = Collections.binarySearch(storage, element);
+
+        if (0 > index) {
+            storage.add(-(index + 1), element);
+        } else {
+            storage.add(index, element);
+        }
+    }
+
+    Optional<Element> at(int tier) {
+        return 0 < tier && tier <= storage.size()
+               ? Optional.of(storage.get(storage.size() - tier))
+               :
+               Optional.empty();
+    }
+}
+```
+
+Would the usual approach of writing tests with hand-written scenarios have found that bug? Maybe, but we don't generally have the benefit of hindsight when doing TDD, for instance. Much better to express a fundamental property of the system under test and then show that it holds in a wide variety of trials, because this is exactly what the real world is going to inflict on our code in production. Here, the property is that the highest values fed to a tiers instance will survive as long as they fit in the number of available tiers.
+
+So far, so good - we have looked at a realistic property test, seen various techniques put together for building up complex trials and learned how to directly reproduce a maximally shrunk failing test case in a single trial for problem diagnosis and remedy.
+
+However, there is something amiss - take a look at the code below, taken from the fixed implementation of `Tiers` but with a _fault injected_ into it to 'test the testing':
+
+```java
+    void add(Element element) {
+        final int index = Collections.binarySearch(storage, element);
+
+        if (0 >= index) /* <<----- FAULT */ {
+            storage.add(-(index + 1), element);
+        } else {
+            storage.add(index, element);
+        }
+    }
+```
+
+This is a useful practice when we want to gain confidence in our testing - if we deliberately inject faults, do our tests find them?
+
+When we try it out, the test _passes_. That's not good, because now there really is a fault. Let's come back to this in a later topic, we can do better by tweaking the trials setup a little. What might the issue be, and how hard would it be to make a test case that exposes the fault?
+
+***
+
+Next topic: [All about shrinkage...]({% link docs/wiki-content/shrinkage.md %})

--- a/gh-pages/docs/wiki-content/shrinkage.md
+++ b/gh-pages/docs/wiki-content/shrinkage.md
@@ -1,0 +1,395 @@
+---
+layout: default
+title: "All about shrinkage"
+parent: Wiki Content
+nav_order: 6
+---
+
+# All about shrinkage
+{: .no_toc }
+
+What it means and how it is achieved
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+We've mentioned shrinkage of test cases that fail their trials, and we know that Americium carries on trialing test cases until it settles on a maximally shrunk test case, at which point it lets the exception out, wrapped up inside a `TrialsFactoring.TrialsException`. So far, the examples of shrunk test cases look sensible enough, and they could be seen to improve when Americium is given a better budget via `.withLimit` - but what does shrinkage really mean?
+
+There are two aspects to shrinking a test case:
+1. The _distance_ of a scalar value from some choice of a maximally shrunk value.
+2. The _complexity_ of a structured test case.
+
+## Distance Shrinkage
+
+An example of the distance aspect can be seen with:
+
+```java
+try {
+    api().doubles(-1e10, 1e10).withLimit(50).supplyTo(input -> {
+        double root = Math.sqrt(input);
+        try {
+            assertThat(Double.isNaN(root), is(false));
+        } catch (Throwable throwable) {
+            System.out.println(input);
+            throw throwable;
+        }
+    });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+We're peeking at the failing cases in the test prior to Americium throwing the final `TrialException`:
+
+```
+-9.105215576676373E9
+-8.6881081547096E9
+-2.1320432384270747E9
+-1.0794530527479506E9
+-3.933015970732623E8
+-9.183900331240854E7
+-4.5931761134104E7
+-3.508276029329806E7
+-5021004.9676793255
+-1696895.33830504
+-1004189.6789330263
+-571909.6722478328
+-404243.60335425945
+-93369.2146621451
+-83588.7870024568
+-13330.019412140715
+-8695.34222429553
+-6065.403802764423
+-1166.2699171308914
+-1127.3063430503917
+-303.38285352351534
+-188.64786072462712
+-72.06401439886594
+-13.348024122637748
+-7.339791923115929
+-4.9339153455115605
+-1.2664547004419962
+-0.8866716952674047
+-0.35113861037577854
+-0.15060597083685345
+-0.05695786073692255
+-0.002145267470610168
+-0.002023332673281586
+-9.146492157413588E-4
+-6.367410938790119E-5
+-5.2134945666137966E-5
+-3.5475095083725705E-6
+-2.0111950299606107E-6
+-3.361026734705064E-7
+-2.0816681711721685E-7
+-8.998878031629687E-8
+-1.0842021724855044E-8
+-9.75781955236954E-9
+-3.2526065174565133E-9
+-1.0842021724855044E-9
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: is <false>
+     but: was <true>
+Case:
+-1.0842021724855044E-9
+Reproduce via Java property:
+trials.recipeHash=a7e81f2abb74d603481ca51f5580e4cb
+Reproduce via Java property:
+trials.recipe="[{\"FactoryInputOf\":{\"input\":-1}}]"
+```
+
+Observe how the initial failure with a very unwieldy -9.105215576676373E9 is whittled down in _magnitude_ to a more tractable -1.0842021724855044E-9. By default, shrinkage of a numeric value will tend to zero - in this case zero would not have caused a failure, so Americium finished off with a negative number that was fairly close.
+
+The target scalar value doesn't have to zero - we can set our own non-zero value:
+
+```java
+try {
+    api().doubles(-1e10, 1e10, -152.753).withLimit(50).supplyTo(input -> {
+        double root = Math.sqrt(input);
+        try {
+            assertThat(Double.isNaN(root), is(false));
+        } catch (Throwable throwable) {
+            System.out.println(input);
+            throw throwable;
+        }
+    });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+This yields:
+
+```
+-9.105215576676373E9
+-8.6881081547096E9
+-2.1320433282770753E9
+-1.079453179597778E9
+-3.9330173915945214E8
+-9.183915167286403E7
+-4.59319120782739E7
+-3.508291230142994E7
+-5021157.413945983
+-1697047.9649936275
+-1004342.3799185539
+-572062.4038285059
+-404396.34753387794
+-93521.9640299518
+-83741.53850673593
+-13482.771796209798
+-8848.094970657274
+-6218.156698316722
+-1319.0228741205913
+-1280.059325338865
+-456.13584622900316
+-341.40085772138707
+-123.19060478808785
+-138.84206515021668
+-145.96222640876596
+-149.37160509742213
+-152.21259671581245
+-153.13683395311975
+-152.72072156768584
+-152.7329599225466
+-152.7498341556772
+-152.75514526747062
+-152.752552542174
+-152.75274498697542
+-152.7529116245125
+-152.75297018877706
+-152.75301079756943
+-152.75300884058453
+-152.75299534660428
+-152.7530002471981
+-152.75300014094628
+-152.75299986122212
+-152.7530000097578
+-152.7530000065052
+-152.752999994579
+-152.7529999978316
+-152.753
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: is <false>
+     but: was <true>
+Case:
+-152.753
+Reproduce via Java property:
+trials.recipeHash=2f4aad6ae7b927bc9948ea3bd0361a64
+Reproduce via Java property:
+trials.recipe="[{\"FactoryInputOf\":{\"input\":-140889774875}}]"
+```
+
+In this case shrinkage actually resulted in the target being the maximally shrunk test case, as -152.753 is negative itself.
+
+Characters can be shrunk in this way too:
+
+```java
+try {
+    api().characters('A', 'z', 'O').withLimit(50).supplyTo(input -> {
+        try {
+            assertThat(input, lessThan('L'));
+        } catch (Throwable throwable) {
+            System.out.println(input);
+            throw throwable;
+        }
+    });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+This yields:
+
+
+```
+h
+f
+`
+^
+]
+O
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: a value less than "L"
+     but: "O" was greater than "L"
+Case:
+O
+Reproduce via Java property:
+trials.recipeHash=3c74a6051f7644c509f231bb81a28609
+Reproduce via Java property:
+trials.recipe="[{\"FactoryInputOf\":{\"input\":79}}]"
+```
+
+There is a wrinkle - characters can be shrunken towards an explicit target, but the other overloads of the `TrialsApi.characters` do not permit shrinkage of their test cases, because there is no obvious default to shrink to. In the same way, the single declaration of `TrialsApi.booleans` doesn't shrink either - true and false are considered to be equally as good.
+
+In fact, any trials instance that is built using `TrialsApi.choose` does **not** allow shrinkage of its test cases. The reason is that a choice is considered to be selection from a set of equally valid possibilities, which don't even have to be numeric. Consider an enumeration type - which enumeration value would we consider to be 'the smallest'?
+
+Transforming a trials that is shrinkable yields another shrinkable trials, but sticks with applying shrinkage to the source trials:
+
+```java
+try {
+    api().doubles(-1e10, 1e10, -152.753).map(value -> -value).withLimit(50).supplyTo(input -> {
+        double root = Math.sqrt(input);
+        try {
+            assertThat(Double.isNaN(root), is(false));
+        } catch (Throwable throwable) {
+            System.out.println(input);
+            throw throwable;
+        }
+    });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+We negate the values, so shrinkage now has to move _positive_ values in source trials in the direction of the target, -152.753. The failure won't occur when the source test values cross over zero, so we see:
+
+```
+-3.71491909402933E9
+-2.966997489796238E9
+-5.358398565224385E8
+-4.998735887849297E8
+-4.8883307204074246E8
+-2.7205589646452326E7
+-1.5053735949196579E7
+-7771300.103947113
+-804220.953759997
+-446390.6461383621
+-278230.77159202314
+-172681.77025061185
+-27150.892720295164
+-9218.593390984895
+-5188.114552733808
+-1698.1378875307025
+-471.58899564324366
+-427.2261595671299
+-391.9060095722816
+-240.27913820334783
+-214.6391853710165
+-38.847600078648334
+-9.375772407182584
+-5.03110396706348
+-3.5805135683959626
+-0.6183243982281343
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: is <false>
+     but: was <true>
+Case:
+-0.6183243982281343
+Reproduce via Java property:
+trials.recipeHash=835bd79ac80e0936cfa78465e83baa72
+Reproduce via Java property:
+trials.recipe="[{\"FactoryInputOf\":{\"input\":570303596}}]"
+```
+
+Americium cares about the manner in which a test case is built up, not the actual test case itself, so shrinkage is applied to the raw material - namely the value produced by the source test case.
+
+## Complexity Shrinkage
+
+Here's an amusing exercise:
+
+```java
+try {
+    final String suffix = "are";
+
+    final int suffixLength = suffix.length();
+
+    api().characters('a', 'z').collections(Builder::stringBuilder).filter(caze -> caze.length() >
+                                                                                  suffixLength).withLimit(20000).supplyTo(input -> {
+        try {
+            assertThat(input, not(endsWith(suffix)));
+        } catch (Throwable throwable) {
+            System.out.println(input);
+            throw throwable;
+        }
+    });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+We're looking for 'words' that end in the suffix "are" but must be longer than the suffix itself.
+
+The result is appropriate, given how many combinations of letters there are:
+
+```
+qzqiare
+rare
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: not a string ending with "are"
+     but: was "rare"
+Case:
+rare
+Reproduce via Java property:
+trials.recipeHash=a231ff98839a0b111a5b4fa213c68fc6
+Reproduce via Java property:
+trials.recipe="[{\"ChoiceOf\":{\"index\":1}},{\"ChoiceOf\":{\"index\":4}},{\"ChoiceOf\":{\"index\":1}},{\"ChoiceOf\":{\"index\":17}},{\"ChoiceOf\":{\"index\":1}},{\"ChoiceOf\":{\"index\":0}},{\"ChoiceOf\":{\"index\":1}},{\"ChoiceOf\":{\"index\":17}},{\"ChoiceOf\":{\"index\":0}}]"
+```
+
+Entertaining coincidence aside, note how shrinkage proceeded from "qzqiare" down to "rare". In this situation, the trials providing the characters will not shrink them as it uses a choice over a character range under the hood. What does happen though is that the strings yielded by the overall trials expression are shrunk down in length - they become less complex.
+
+To reiterate, Americium cares about the manner in which a test case is built up, not the actual test case itself, and here it keeps track of how many degrees of freedom of variation the final test cases has - this is what we mean by complexity. The subexpression `api().characters('a', 'z').collections(Builder::stringBuilder)` is building a string - a kind of collection - whose elements are taken from repeated usages of the same trials instance for characters, namely the `api().characters('a', 'z')` part - each repetition adds another degree of freedom of variation, pushing up the complexity. So a 7-letter string like "qzqiare" will be more complex than a 4-letter string like "rare".
+
+Americium tries to reduce complexity of its failing test cases, and will do so in tandem with distance shrinkage on the components of the overall final test case.
+
+Let's see that in action:
+
+```java
+try {
+    api()
+            .integers(1, 20)
+            .flatMap(api().integers(0,
+                                    Integer.MAX_VALUE)::immutableListsOfSize)
+            .withLimit(15)
+            .supplyTo(input -> {
+                try {
+                    final int sum =
+                            input.stream().reduce(Integer::sum).orElse(0);
+                    assertThat(sum, not(lessThan(0)));
+                } catch (Throwable throwable) {
+                    System.out.println(input);
+                    throw throwable;
+                }
+            });
+} catch (TrialsScaffolding.TrialException exception) {
+    System.out.println(exception);
+}
+```
+
+So one degree of freedom controls the length of the lists that are reduced, and there are degrees of freedom for each trials that contributed an integer to the overall list test case:
+
+```
+[805257284, 301232032, 657251477, 730815669, 1244866410]
+[1116753496, 1903765060, 156227821]
+[635805210, 70022358, 1813976772]
+[2017271885, 1302899322]
+[1942017441, 447615689]
+Trial exception with underlying cause:
+java.lang.AssertionError:
+Expected: not a value less than <0>
+     but: was <-1905334166>
+Case:
+[1942017441, 447615689]
+Reproduce via Java property:
+trials.recipeHash=f94c17dd67adc49fa57b2467a233229e
+Reproduce via Java property:
+trials.recipe="[{\"FactoryInputOf\":{\"input\":2}},{\"FactoryInputOf\":{\"input\":447615689}},{\"FactoryInputOf\":{\"input\":1942017441}}]"
+```
+
+See how the lists contract in size, but there is shrinkage applied to the individual values too. This example is a tricky one, as the shorter the list test cases get, the larger the individual list elements have to be to cause overflow - so shrinkage has to pick its way between just shrinking the distances of all the elements from zero with shrinking the complexity.
+
+It is possible to customise how a trials generates a scalar value and take more control over the lower bound, upper bound and shrinkage target - but we'll leave that for a later topic.
+
+***
+Next topic: [Configuration buttons, dials and levers...]({% link docs/wiki-content/configuration.md %})

--- a/gh-pages/docs/wiki-content/techniques.md
+++ b/gh-pages/docs/wiki-content/techniques.md
@@ -1,0 +1,586 @@
+---
+layout: default
+title: "Techniques"
+parent: Wiki Content
+nav_order: 10
+---
+
+# Techniques
+{: .no_toc }
+
+Impress your friends with sleights of hand
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+## Forcing lots of duplicates
+
+Remember the `Tiers` example? There was a cliffhanger where a fault was injected, but the test still passed. Naughty.
+
+```java
+    void add(Element element) {
+        final int index = Collections.binarySearch(storage, element);
+
+        if (0 >= index) /* <<----- FAULT */ {
+            storage.add(-(index + 1), element);
+        } else {
+            storage.add(index, element);
+        }
+    }
+```
+
+This is definitely a bug, so why isn't Americium exposing it?
+
+We start by increasing the limit from 10 in the JUnit5 version of the test, and after a lot of experimentation we hit on:
+
+```java
+    @TrialsTest(trials = "testCases", casesLimit = 11000)
+    void tiersShouldRetainTheLargestElements(ImmutableList<Integer> queryValues,
+                                             ImmutableList<Integer> feedSequence){
+...
+}
+```
+
+This yields:
+
+![](https://raw.githubusercontent.com/sageserpent-open/americium/5d86a9bd622efa94b5059c4d8c68fa8c15a02a12/screenshots/TiersInJUnit5WithAVeryHighLimit.png)
+
+Don't be fooled by the times reported for the tests - IntelliJ has a nervous breakdown while it processes the 89490 trials over all of the cycles and takes a while to recover. Fortunately all of the individual trials were quite snappy, but imagine if there was some IO involved in the test - that would take a _long_ time to run.
+
+We can see the problem now: this is something to do with adjacent duplicates being presented to the tiers instance; the thing is, we allow the query values to vary all over the place:
+
+```java
+    private final static Trials<ImmutableList<Integer>> queryValueLists = api()
+            .integers(-1000, 1000)
+            .immutableLists()
+            .filter(list -> !list.isEmpty());
+```
+
+So yes, Americium will eventually generate duplicates, but we need to be patient. Very patient.
+
+Now we could simply force the issue by restricting those query values down to a small range, say -1 to 1, but even that requires the limit to be increased, and we want to have the full generality in our test and go stomping around over lots of integers.
+
+There is a trick to encourage duplication of values in collections:
+
+```java
+    private final static Trials<ImmutableList<Integer>> queryValueLists = api()
+            .integers(1, 10)
+            .flatMap(numberOfChoices -> api()
+                    .integers(-1000, 1000)
+                    .immutableListsOfSize(
+                            numberOfChoices)
+                    .flatMap(choices -> api()
+                            .choose(choices)
+                            .immutableListsOfSize(
+                                    numberOfChoices)));
+```
+
+What we are doing here is to make choices of integer values in the outer flat-map sequence, then inject a _specific_ group of choices into the inner flat-map. That inner flat-map then builds a list whose elements are taken from just that group, so there is a high probability of duplication; we are building a list with `numberOfChoices` elements, each of these elements has a value belonging to the same pool of size `numberOfChoices` - so unless all the element choices conspire to avoid each other, we'll see the same value get picked twice or maybe more.
+
+Pushing the limit up to a modest 30 yields:
+
+![](https://raw.githubusercontent.com/sageserpent-open/americium/329e894664eb183af43e48d84a5be239d6994f5a/screenshots/TiersInJUnit5WithBetterDuplicateValueGeneration.png)
+
+That's just 69 trials to result in the optimally shrunk case, much better.
+
+## Unique ids when building `Trials`
+
+Here'a a model of a group of participants, extended to allow subgroups to be made members of groups too. Typical corporate distribution list stuff.
+
+```java
+public class Group {
+    private final String name;
+
+    private final List<Either<Group, String>> members;
+
+    public Group(String name, List<Either<Group, String>> members) {
+        this.name = name;
+        this.members = members;
+    }
+
+    public void checkUniquenessOfNames() {
+        gatherNamesInto(new HashSet<>());
+    }
+
+    void gatherNamesInto(Set<String> gatheredNames) {
+        Preconditions.checkState(gatheredNames.add(name));
+
+        members.forEach(either -> either.bipeek(
+                group -> group.gatherNamesInto(gatheredNames),
+                participant -> {
+                    Preconditions.checkState(gatheredNames.add(participant));
+                }));
+    }
+
+    public int maximumDepth() {
+        return 1 + members
+                .stream()
+                .map(either -> either.fold(Group::maximumDepth,
+                                           unused -> 0))
+                .reduce(0, Integer::max);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Group: %s, maximum depth: %d, members: (%s)",
+                             name,
+                             maximumDepth(),
+                             members
+                                     .stream()
+                                     .map(either -> either.fold(Group::toString,
+                                                                Function.identity()))
+                                     .collect(Collectors.toList()));
+    }
+}
+```
+
+When we test over instances of `Group`, we want to build up some decent structure for our test cases, so some kind of recursive formulation comes to mind. All very well, except that we expect the groups and participants that are direct or indirect members of our top-level group to have unique names. How do we ensure this when names are presumably chosen arbitrarily?
+
+Yes, we could do something like this:
+
+```java
+api().delay(() -> api().only(UUID.randomUUID())).map(UUID::toString)
+```
+
+That gives us unique names, but they are unreadable - our tiny human minds prefer simple readable things like small integers! The lack of repeatability between runs due to using `UUID` is also annoying.
+
+Behold `TrialsApi.uniqueIds`:
+
+```java
+class Module {
+    public static Trials<Group> groups() {
+        final Trials<String> groupNames =
+                api()
+                        .uniqueIds()
+                        .map(id -> String.format("Group-%d", id));
+
+        final Trials<String> participantNames =
+                api()
+                        .uniqueIds()
+                        .map(id -> String.format("Participant-%d", id));
+
+
+        final Trials<ImmutableList<Either<Group, String>>> memberLists =
+                api()
+                        .delay(Module::groups)
+                        .or(participantNames)
+                        .immutableLists();
+
+        return groupNames.flatMap(name -> memberLists.map(members -> new Group(
+                name,
+                members)));
+    }
+}
+
+Module.groups().withLimit(10).supplyTo(group -> {
+    System.out.println(group);
+    group.checkUniquenessOfNames();
+});
+```
+
+This test passes nicely:
+
+```
+Group: Group-0, maximum depth: 2, members: ([Group: Group-1, maximum depth: 1, members: ([])])
+Group: Group-0, maximum depth: 1, members: ([])
+Group: Group-0, maximum depth: 1, members: ([Participant-1])
+Group: Group-0, maximum depth: 1, members: ([Participant-2, Participant-1])
+Group: Group-0, maximum depth: 6, members: ([Participant-28, Participant-27, Group: Group-6, maximum depth: 5, members: ([Group: Group-14, maximum depth: 4, members: ([Group: Group-20, maximum depth: 3, members: ([Participant-26, Group: Group-24, maximum depth: 2, members: ([Group: Group-25, maximum depth: 1, members: ([])]), Group: Group-22, maximum depth: 1, members: ([Participant-23]), Group: Group-21, maximum depth: 1, members: ([])]), Group: Group-15, maximum depth: 2, members: ([Group: Group-18, maximum depth: 1, members: ([Participant-19]), Group: Group-17, maximum depth: 1, members: ([]), Group: Group-16, maximum depth: 1, members: ([])])]), Group: Group-10, maximum depth: 2, members: ([Participant-13, Group: Group-11, maximum depth: 1, members: ([Participant-12])]), Group: Group-9, maximum depth: 1, members: ([]), Participant-8, Participant-7]), Participant-5, Group: Group-4, maximum depth: 1, members: ([]), Participant-3, Group: Group-1, maximum depth: 1, members: ([Participant-2])])
+Group: Group-0, maximum depth: 5, members: ([Participant-9, Participant-8, Group: Group-4, maximum depth: 4, members: ([Group: Group-5, maximum depth: 3, members: ([Group: Group-6, maximum depth: 2, members: ([Group: Group-7, maximum depth: 1, members: ([])])])]), Group: Group-2, maximum depth: 1, members: ([Participant-3]), Group: Group-1, maximum depth: 1, members: ([])])
+Group: Group-0, maximum depth: 4, members: ([Group: Group-7, maximum depth: 1, members: ([]), Participant-6, Participant-5, Group: Group-1, maximum depth: 3, members: ([Group: Group-2, maximum depth: 2, members: ([Participant-4, Group: Group-3, maximum depth: 1, members: ([])])])])
+Group: Group-0, maximum depth: 3, members: ([Group: Group-2, maximum depth: 2, members: ([Group: Group-3, maximum depth: 1, members: ([Participant-7, Participant-6, Participant-5, Participant-4])]), Participant-1])
+Group: Group-0, maximum depth: 2, members: ([Participant-5, Group: Group-1, maximum depth: 1, members: ([Participant-4, Participant-3, Participant-2])])
+Group: Group-0, maximum depth: 2, members: ([Group: Group-2, maximum depth: 1, members: ([]), Participant-1])
+```
+
+See how within each test case, the integer ids yielded by `TrialsApi.uniqueIds` are all different. They are nevertheless repeatable and if a test case fails, reproducable with the same values. The uniqueness only holds *within* a given test case - we won't see any 'creep' of ids from one test case to another, specific ids can and will reappear across unrelated test cases.
+
+## Permutations
+
+A common pattern in property-based testing to to take an expected output that is correct by construction, then demolish it and use the resulting pieces as input to the test.
+
+For example, it is easy to generate a run of increasing values; we'll do this in Scala for a change:
+
+```scala
+api
+  .choose(0 until 5)
+  .several[Vector[Int]]
+  .flatMap(increments =>
+    api.choose(-10 to 10).map(base => increments.scanLeft[Int](base)(_ + _))
+  )
+  .withLimit(10)
+  .supplyTo(println)
+```
+
+This yields:
+
+```
+Vector(7, 8)
+Vector(3)
+Vector(6, 10)
+Vector(4)
+Vector(-7, -5)
+Vector(-5)
+Vector(-3, 0, 2, 2)
+Vector(1)
+Vector(-4)
+Vector(-1, 3, 6)
+```
+
+Note the presence of duplicates too, that's nice.
+
+Now we have that technique in hand, we can test yet another sorting algorithm by permuting these test cases, feeding them into the sorting algorithm and verifying that what comes out is the same as what we started with.
+
+We'll demonstrate using `TrialsApi.indexPermutations` to do this, let's see what it does first:
+
+```scala
+api.indexPermutations(0).withLimit(15).supplyTo(println)
+// Vector()
+
+api.indexPermutations(1).withLimit(15).supplyTo(println)
+// Vector(0)
+
+api.indexPermutations(2).withLimit(15).supplyTo(println)
+// Vector(1, 0)
+// Vector(0, 1)
+
+api.indexPermutations(3).withLimit(15).supplyTo(println)
+// Vector(1, 0, 2)
+// Vector(2, 1, 0)
+// Vector(1, 2, 0)
+// Vector(0, 2, 1)
+// Vector(0, 1, 2)
+// Vector(2, 0, 1)
+
+api.indexPermutations(4).withLimit(50).supplyTo(println)
+// Vector(2, 0, 3, 1)
+// Vector(3, 1, 2, 0)
+// Vector(2, 3, 0, 1)
+// Vector(2, 3, 1, 0)
+// Vector(2, 0, 1, 3)
+// Vector(1, 2, 0, 3)
+// Vector(1, 0, 2, 3)
+// etc...
+```
+
+This yields permutations of a range of integers from zero up to but not including the size of the range. You are encouraged to think of these integers as being indices into some implied collection of items of the same size, hence the name of the method.
+
+Here's an example where we take a nice, simple collection of `0 until size`, permute it, then feed it to a test that will fail if at least two adjacent elements are not in non-strict ascending order:
+
+```scala
+val permutations: Trials[SortedMap[Int, Int]] =
+  api.only(15).flatMap { size =>
+    val sourceCollection = 0 until size
+
+    api
+      .indexPermutations(size)
+      .map(indices => {
+        val permutation = SortedMap.from(indices.zip(sourceCollection))
+
+        assume(permutation.size == size)
+
+        assume(SortedSet.from(permutation.values).toSeq == sourceCollection)
+
+        permutation
+      })
+  }
+
+try {
+  permutations
+    .withLimit(15)
+    .supplyTo { permuted =>
+      Trials.whenever(permuted.nonEmpty) {
+        permuted.values zip permuted.values.tail foreach { case (left, right) =>
+          if (left > right) {
+            println(permuted.values)
+
+            throw new RuntimeException
+          }
+        }
+      }
+    }
+} catch {
+  case exception: permutations.TrialException =>
+    println(exception)
+}
+```
+
+Here, we transform the permutations generated by `api.indexPermutations(size)`, zipping `indices` with `sourceCollection` and turning that into a map sorted on the indices; this rearranges the original elements in `sourceCollection` according to the _inverse_ of the index permutation.
+
+We could have also used `indices` as a direct permutation of integers in its own right; this works if the collection being permuted is a zero-relative range of contiguous integers, but here we have stuck with an explicit rearrangement of the original collection.
+
+We could also have permuted on-the-fly by composing lookups to yield a lambda that accesses permuted items:
+
+```scala
+val inPermutationAt: Int => Int = indices.andThen(sourceCollection)
+```
+
+That last approach works well if you don't want to use the collection as a collection with a size, ability to add / remove elements etc - you just need random access to what's in it.
+
+Anyway, shrinkage proceeds like this:
+
+```
+Iterable(8, 1, 13, 12, 11, 9, 6, 4, 10, 14, 0, 3, 5, 7, 2)
+Iterable(8, 5, 7, 0, 1, 4, 3, 13, 6, 2, 11, 10, 14, 9, 12)
+Iterable(9, 4, 1, 0, 5, 3, 2, 7, 8, 6, 12, 13, 11, 10, 14)
+Iterable(4, 1, 5, 0, 2, 3, 6, 8, 11, 9, 13, 10, 7, 14, 12)
+Iterable(1, 0, 2, 4, 3, 5, 6, 9, 8, 7, 11, 14, 10, 12, 13)
+Iterable(1, 0, 2, 4, 3, 5, 6, 8, 7, 11, 10, 9, 12, 13, 14)
+Iterable(1, 0, 2, 3, 4, 5, 6, 8, 7, 9, 10, 11, 12, 13, 14)
+Iterable(1, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 13)
+Iterable(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 12, 13)
+Iterable(0, 1, 2, 3, 4, 5, 6, 7, 9, 8, 10, 11, 12, 13, 14)
+Trial exception with underlying cause:
+java.lang.RuntimeException
+Case:
+TreeMap(0 -> 0, 1 -> 1, 2 -> 2, 3 -> 3, 4 -> 4, 5 -> 5, 6 -> 6, 7 -> 7, 8 -> 9, 9 -> 8, 10 -> 10, 11 -> 11, 12 -> 12, 13 -> 13, 14 -> 14)
+Reproduce via Java property:
+trials.recipeHash=75462f61356dc6336a88b40dd7a4f2fa
+```
+
+So the higgledy-piggledy permutation that gave us the first failing trial has been straightened out to a more tractable failing test case with just one pair of mapped values the wrong way around - 9 and 8. Much better!
+
+## Alternate Picking
+
+Put your guitar back down, we're talking about picking items between sequences to make a merged sequence. Suppose we have sequences of positive odd, positive even and negative numbers:
+
+```java
+final List<Integer> odds = Stream
+        .iterate(1, x -> 2 + x)
+        .limit(10)
+        .collect(Collectors.toList());
+
+final List<Integer> evens = Stream
+        .iterate(0, x -> 2 + x)
+        .limit(15)
+        .collect(Collectors.toList());
+
+final List<Integer> negatives = Stream
+        .iterate(-1, x -> x - 1)
+        .limit(7)
+        .collect(Collectors.toList());
+```
+
+Let's see what happens when we pick alternately, shrinking towards round-robin picking on failure:
+
+```java
+
+final Trials<List<Integer>> thingsThatShrinkToRoundRobinPicking =
+        api().pickAlternatelyFrom(true,
+                                  odds, evens, negatives);
+
+thingsThatShrinkToRoundRobinPicking
+        .withLimit(10)
+        .supplyTo(System.out::println);
+// [0, 1, 3, 5, 2, 4, 7, 9, -1, 11, 13, -2, 15, 6, -3, 17, -4, 19, -5, 8, -6, 10, 12, 14, -7, 16, 18, 20, 22, 24, 26, 28]
+// [0, 2, 1, 3, -1, 5, 7, -2, 4, -3, 6, 8, -4, 9, -5, -6, 10, 12, -7, 11, 13, 14, 16, 18, 15, 17, 19, 20, 22, 24, 26, 28]
+// [1, 0, 3, 2, 5, 7, 4, -1, 6, -2, 9, 11, 13, 15, 17, 19, -3, 8, 10, -4, -5, -6, -7, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [0, -1, -2, 2, 4, -3, 1, 6, -4, 8, 3, 10, 12, 14, 16, 5, 18, 7, 20, 9, 11, 22, 24, -5, 13, -6, 26, -7, 28, 15, 17, 19]
+// [-1, 0, -2, 1, -3, -4, 2, 3, 4, 5, -5, 7, -6, 6, -7, 8, 10, 9, 12, 14, 11, 16, 18, 20, 22, 13, 24, 15, 17, 26, 19, 28]
+// [-1, 0, -2, 2, -3, 4, -4, -5, 6, -6, -7, 1, 3, 5, 8, 7, 10, 12, 14, 16, 9, 18, 11, 13, 15, 20, 17, 19, 22, 24, 26, 28]
+// [1, 3, -1, 5, 7, -2, -3, 9, 0, 11, 13, -4, 15, -5, -6, 17, 2, 19, 4, -7, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, 0, 2, 5, 4, 6, 7, 8, 9, 11, 10, 13, 12, 15, 14, -1, 16, -2, 17, -3, 19, 18, -4, 20, -5, 22, 24, -6, 26, -7, 28]
+// [0, 2, -1, -2, -3, 4, 1, -4, 6, 8, -5, -6, 10, -7, 12, 3, 5, 14, 7, 9, 16, 18, 11, 20, 22, 13, 24, 15, 26, 17, 19, 28]
+// [0, 1, -1, 3, -2, 5, -3, 7, -4, 9, -5, 11, 2, -6, 4, 6, -7, 8, 13, 15, 17, 10, 19, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+
+thingsThatShrinkToRoundRobinPicking.withLimit(10).supplyTo(sequence -> {
+    System.out.println(sequence);
+    throw new RuntimeException();
+});
+// [0, 1, 3, 5, 2, 4, 7, 9, -1, 11, 13, -2, 15, 6, -3, 17, -4, 19, -5, 8, -6, 10, 12, 14, -7, 16, 18, 20, 22, 24, 26, 28]
+// [-1, 0, -2, 1, -3, -4, 2, 3, 4, 5, -5, 7, -6, 6, -7, 8, 10, 9, 12, 14, 11, 16, 18, 20, 22, 13, 24, 15, 17, 26, 19, 28]
+// [-1, 0, 1, -2, 3, -3, 2, 5, 4, 7, -4, 6, -5, 9, -6, -7, 11, 8, 13, 15, 10, 17, 12, 19, 14, 16, 18, 20, 22, 24, 26, 28]
+// [-1, 0, 1, -2, 2, -3, 3, 4, 5, 6, -4, 7, 8, -5, 9, -6, 10, 11, 13, -7, 12, 15, 14, 17, 16, 19, 18, 20, 22, 24, 26, 28]
+// [0, -1, 2, 1, -2, 4, 3, -3, 6, -4, 5, 8, 7, -5, 10, 9, -6, 12, -7, 11, 14, 16, 13, 18, 15, 20, 17, 22, 19, 24, 26, 28]
+// [1, 0, -1, 3, 2, -2, 5, 4, -3, 6, 7, -4, 9, 8, -5, 11, 10, -6, 12, 13, -7, 15, 14, 17, 16, 19, 18, 20, 22, 24, 26, 28]
+// [1, 0, -1, 3, 2, -2, 5, 4, -3, 6, 7, -4, 9, 8, -5, 11, 10, -6, 13, 12, 15, 14, -7, 17, 16, 19, 18, 20, 22, 24, 26, 28]
+// [1, 0, -1, 3, 2, -2, 5, 4, -3, 6, 7, -4, 8, 9, -5, 10, 11, -6, 12, 13, 14, 15, -7, 16, 17, 18, 19, 20, 22, 24, 26, 28]
+// [1, 0, -1, 3, 2, -2, 5, 4, -3, 6, 7, -4, 8, 9, -5, 10, 11, -6, 12, 13, -7, 14, 15, 16, 17, 18, 19, 20, 22, 24, 26, 28]
+// [1, 0, -1, 3, 2, -2, 5, 4, -3, 7, 6, -4, 9, 8, -5, 11, 10, -6, 13, 12, -7, 15, 14, 17, 16, 19, 18, 20, 22, 24, 26, 28]
+```
+
+The trials resulting from `TrialsApi.pickAlternatelyFrom` yield cases that are merges of the three sequences, respecting the order of the elements in each sequence, but alternating between them in a manner that varies from case to case.
+
+Failures cause shrinkage towards a round-robin merge of the three sequences, so we see their elements interleaved in the maximally shrunk case. All of the sequences will be drained regardless of length, so we see a trailing section just from the even number sequence.
+
+Let's change the first argument to `TrialsApi.pickAlternatelyFrom` to be false:
+
+```java
+final Trials<List<Integer>> thingsThatShrinkToConcatenation =
+        api().pickAlternatelyFrom(false,
+                                  odds, evens, negatives);
+
+thingsThatShrinkToConcatenation.withLimit(10).supplyTo(System.out::println);
+// [0, 2, -1, 1, -2, 4, -3, 3, 5, -4, 6, -5, 8, 10, 12, 14, -6, 16, -7, 18, 20, 22, 7, 24, 26, 9, 11, 28, 13, 15, 17, 19]
+// [-1, -2, 1, 0, 3, 5, 2, 7, -3, 9, 11, -4, 4, 6, 13, 8, 10, -5, -6, 15, 12, 17, -7, 14, 19, 16, 18, 20, 22, 24, 26, 28]
+// [0, 1, -1, 3, 5, -2, 7, 9, 2, -3, 11, 4, -4, 6, 8, 10, -5, -6, 12, -7, 13, 14, 15, 16, 17, 18, 19, 20, 22, 24, 26, 28]
+// [1, 3, 0, 2, 5, -1, 4, 7, 6, 9, 8, 11, 10, -2, 12, 13, 15, 17, 14, 16, 19, -3, 18, -4, -5, 20, 22, 24, -6, -7, 26, 28]
+// [0, 1, 3, 2, 5, 7, 4, -1, 6, -2, -3, -4, 9, 11, 13, 8, 15, 10, 17, 12, 19, -5, -6, 14, -7, 16, 18, 20, 22, 24, 26, 28]
+// [0, 1, 2, 3, 4, -1, 6, -2, 5, 7, -3, 9, 8, 11, 13, 15, -4, 10, 17, 19, 12, 14, -5, -6, -7, 16, 18, 20, 22, 24, 26, 28]
+// [0, 1, -1, 3, 2, 5, 7, 4, -2, -3, 6, -4, 9, -5, -6, 11, -7, 8, 10, 12, 13, 15, 14, 16, 18, 17, 20, 19, 22, 24, 26, 28]
+// [0, 1, 2, 3, 4, 6, 5, 8, 10, 7, 12, -1, 14, -2, 16, -3, -4, 9, -5, 11, 13, -6, -7, 15, 18, 17, 20, 19, 22, 24, 26, 28]
+// [1, 3, -1, 5, 0, 7, 2, -2, 9, 11, -3, -4, 13, -5, 15, -6, 17, -7, 19, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, 5, 0, -1, 2, 4, 6, -2, 8, -3, 10, -4, 12, -5, 14, -6, -7, 16, 7, 9, 18, 20, 11, 22, 24, 26, 28, 13, 15, 17, 19]
+
+thingsThatShrinkToConcatenation.withLimit(10).supplyTo(sequence -> {
+    System.out.println(sequence);
+    throw new RuntimeException();
+// [0, 2, -1, 1, -2, 4, -3, 3, 5, -4, 6, -5, 8, 10, 12, 14, -6, 16, -7, 18, 20, 22, 7, 24, 26, 9, 11, 28, 13, 15, 17, 19]
+// [0, 1, 3, 2, 5, 7, 4, -1, 6, -2, -3, -4, 9, 11, 13, 8, 15, 10, 17, 12, 19, -5, -6, 14, -7, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, -1, 5, 0, 7, 2, -2, 9, 11, -3, -4, 13, -5, 15, -6, 17, -7, 19, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, 5, 0, -1, 2, 4, 6, -2, 8, -3, 10, -4, 12, -5, 14, -6, -7, 16, 7, 9, 18, 20, 11, 22, 24, 26, 28, 13, 15, 17, 19]
+// [0, -1, -2, 2, -3, -4, 4, -5, -6, -7, 6, 1, 8, 10, 12, 14, 16, 18, 3, 5, 7, 9, 20, 22, 11, 13, 15, 24, 17, 26, 19, 28]
+// [0, 2, 1, -1, 3, 5, -2, -3, -4, 7, -5, 9, 11, 13, 15, -6, -7, 17, 19, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, 5, 0, 7, 9, 11, 13, 15, 2, 4, 17, 19, 6, -1, -2, 8, -3, -4, -5, -6, -7, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, 5, 0, 7, 9, 11, 13, 15, 2, 4, 17, 19, 6, 8, 10, -1, 12, 14, 16, 18, 20, 22, 24, 26, 28, -2, -3, -4, -5, -6, -7]
+// [1, 3, 5, 0, 7, 9, 11, 13, 15, 17, 19, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, -1, -2, -3, -4, -5, -6, -7]
+// [1, 3, 5, 0, 2, 4, 6, 8, 10, 12, 14, 7, 9, 11, 13, 15, 17, 19, 16, 18, 20, 22, 24, 26, 28, -1, -2, -3, -4, -5, -6, -7]
+// [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, -1, -2, -3, -4, -5, -6, -7, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28]
+// [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, -1, -2, -3, -4, -5, -6, -7]
+```
+
+This doesn't significantly affect how cases are generated in the absence of failures - again, they are just merges of the three sequences that respect each sequence's element order.
+
+However, failures cause shrinkage towards sequential drainage of the sequences, which at maximal shrinkage is their concatenation.
+
+## Complexity Budgeting
+
+Let's build test cases that are trees. This is useful for job interviewing, where the idea is to pressure a candidate into sweating over a puzzle that bears no relation to what we really want them to do, but does provide a convenient excuse for not hiring if the panel doesn't instinctively like them.
+
+They present a tree structure in Scala:
+
+```scala
+import scala.collection.immutable.SortedMap
+import cats.instances.map._
+import cats.kernel.Monoid
+import cats.syntax.monoid
+
+sealed trait Tree {
+  def maximumDepth: Int
+
+  def depthFrequencies: SortedMap[Int, Int]
+}
+
+case class Leaf(value: Int) extends Tree {
+  override def maximumDepth: Int = 1
+
+  override def depthFrequencies: SortedMap[Int, Int] = SortedMap(1 -> 1)
+}
+
+case class Branching(subtrees: List[Tree]) extends Tree {
+  require(subtrees.nonEmpty)
+
+  override def maximumDepth: Int =
+    1 + subtrees.map(_.maximumDepth).max
+
+  override def depthFrequencies: SortedMap[Int, Int] = subtrees
+    .map(_.depthFrequencies)
+    // INTERVIEW BONUS QUESTION: what does this line mean?
+    .reduce[SortedMap[Int, Int]](Monoid.combine)
+    .map { case (value, frequency) => (1 + value) -> frequency }
+}
+```
+
+We feel puzzled and anxious. The question is, how would we write a smoke test for such a thing?
+
+Let's try this:
+
+```scala
+def trees: Trials[Tree] = api.alternate(
+  api.uniqueIds.map(Leaf.apply),
+  api
+    .integers(1, 5)
+    .flatMap(numberOfSubtrees =>
+      trees.listsOfSize(numberOfSubtrees).map(Branching.apply)
+    )
+)
+
+trees.withLimit(10).supplyTo { tree =>
+  println(
+    s"Tree: $tree,\nmaximum depth: ${tree.maximumDepth} with depth frequencies: ${tree.depthFrequencies}\n"
+  )
+}
+```
+
+That didn't work very well...
+
+```
+Tree: Leaf(0),
+maximum depth: 1 with depth frequencies: TreeMap(1 -> 1)
+
+Tree: Branching(List(Branching(List(Leaf(3), Branching(List(Leaf(2), Leaf(1))))), Leaf(0))),
+maximum depth: 4 with depth frequencies: TreeMap(2 -> 1, 3 -> 1, 4 -> 2)
+
+Tree: Branching(List(Leaf(2), Leaf(1), Leaf(0))),
+maximum depth: 2 with depth frequencies: TreeMap(2 -> 3)
+
+Tree: Branching(List(Leaf(1), Leaf(0))),
+maximum depth: 2 with depth frequencies: TreeMap(2 -> 2)
+```
+
+It seems the generation ran out of steam early, so we just got a few stunted trees. Part of the problem is that it is too easy to recurse to very deep levels of complexity, and this breaches the default complexity limit, so very few cases actually get generated. Those that do have very low complexity, hence their lack of size.
+
+An interviewer sighs and writes something down, pausing to consult their mobile device inscrutably. Could we do better?
+
+We redouble our efforts, and this time we get this...
+
+```scala
+def statelyTrees: Trials[Tree] = api.complexities.flatMap(complexity =>
+  api.alternateWithWeights(
+    complexity -> api.uniqueIds.map(Leaf.apply),
+    2 -> api
+      .integers(1, 5)
+      .flatMap(numberOfSubtrees =>
+        statelyTrees.listsOfSize(numberOfSubtrees).map(Branching.apply)
+      )
+  )
+)
+
+statelyTrees.withLimit(10).supplyTo { tree =>
+  println(
+    s"stately tree: $tree,\nmaximum depth: ${tree.maximumDepth} with depth frequencies: ${tree.depthFrequencies}\n"
+  )
+}
+```
+
+This yields:
+
+```
+stately tree: Branching(List(Leaf(19), Branching(List(Leaf(18), Branching(List(Leaf(17), Leaf(16), Leaf(15))), Branching(List(Branching(List(Leaf(14), Leaf(13))), Branching(List(Leaf(12))), Branching(List(Leaf(11), Leaf(10), Leaf(9), Branching(List(Leaf(8), Leaf(7), Leaf(6), Leaf(5))), Leaf(4))), Leaf(3), Leaf(2))), Leaf(1))), Branching(List(Leaf(0))))),
+maximum depth: 6 with depth frequencies: TreeMap(2 -> 1, 3 -> 3, 4 -> 5, 5 -> 7, 6 -> 4)
+
+stately tree: Branching(List(Leaf(1), Leaf(0))),
+maximum depth: 2 with depth frequencies: TreeMap(2 -> 2)
+
+stately tree: Branching(List(Branching(List(Leaf(2), Leaf(1))), Leaf(0))),
+maximum depth: 3 with depth frequencies: TreeMap(2 -> 1, 3 -> 2)
+
+stately tree: Branching(List(Branching(List(Leaf(14), Branching(List(Branching(List(Leaf(13), Leaf(12))), Leaf(11))))), Branching(List(Leaf(10), Leaf(9))), Branching(List(Leaf(8), Branching(List(Branching(List(Leaf(7), Leaf(6), Leaf(5))), Leaf(4), Branching(List(Leaf(3))), Leaf(2))), Leaf(1))), Leaf(0))),
+maximum depth: 5 with depth frequencies: TreeMap(2 -> 1, 3 -> 5, 4 -> 3, 5 -> 6)
+
+stately tree: Branching(List(Leaf(1), Leaf(0))),
+maximum depth: 2 with depth frequencies: TreeMap(2 -> 2)
+
+stately tree: Branching(List(Leaf(31), Branching(List(Leaf(30), Leaf(29), Leaf(28), Leaf(27))), Branching(List(Leaf(26), Branching(List(Branching(List(Leaf(25), Leaf(24), Leaf(23), Leaf(22))), Leaf(21), Branching(List(Leaf(20), Leaf(19), Branching(List(Leaf(18), Branching(List(Leaf(17))), Leaf(16))))), Leaf(15), Branching(List(Leaf(14), Branching(List(Leaf(13), Leaf(12), Leaf(11), Leaf(10))))))), Leaf(9))), Branching(List(Leaf(8), Branching(List(Branching(List(Leaf(7))), Branching(List(Leaf(6), Leaf(5), Leaf(4), Leaf(3), Leaf(2))), Branching(List(Leaf(1))), Leaf(0))))))),
+maximum depth: 7 with depth frequencies: TreeMap(2 -> 1, 3 -> 7, 4 -> 3, 5 -> 14, 6 -> 6, 7 -> 1)
+
+etc...
+```
+
+That's more like it, looks like an offer might be on its way. No, the interviewer didn't understand the technique, and has got in a huff. Bad luck, try somewhere else...
+
+What's going on here is driven by the alternation between a leaf node and further branching in `statelyTrees`. The terminating leaf node alternative is weighted by the complexity of its calling context, whereas the branching gets a fixed weight.
+
+This means that to start with, branching is favoured, which deepens the potential tree being built.
+
+Now as the recursion deepens through calls to `statelyTrees`, the complexity retrieved by `api.complexities` goes up, so as the potential tree gets deeper, the alternation swings round to favour leaves over branching. This stops runaway recursion and keeps the test cases below the default complexity limit.
+
+***
+Next topic: [The competition...]({% link docs/wiki-content/competition.md %})

--- a/gh-pages/docs/wiki-content/variations.md
+++ b/gh-pages/docs/wiki-content/variations.md
@@ -1,0 +1,179 @@
+---
+layout: default
+title: "Variations in making a trials instance"
+parent: Wiki Content
+nav_order: 2
+---
+
+# Variations in making a trials instance
+{: .no_toc }
+
+Choices, alternation, special cases
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+
+Supplying arbitrary integers, doubles, booleans etc is all very well, but sometimes we have things like enumerations that range over a fixed number of possibilities that are all equally as important - and unknown to Americium. What do we do then?
+
+Let's revisit our simple test from the beginning - just print out the values of an enumeration:
+
+```java
+
+import javax.net.ssl.SSLEngineResult;
+
+final Trials<SSLEngineResult.Status> trials = Trials.api().choose(SSLEngineResult.Status.values());
+
+trials.withLimit(10).supplyTo(System.out::println);
+
+```
+
+This passes:
+
+```
+CLOSED
+OK
+BUFFER_UNDERFLOW
+BUFFER_OVERFLOW
+```
+
+Note how there are only four enumeration values in `SSLEngineResult.Status`, so even though we specified a limit of 10, Americium did not bother repeating the same trials.
+
+`TrialsApi.choose` can be used with any kind of type - the idea is that we want to explicitly set out the permitted values for Americium to choose from. They are not chosen in any particular order, though - and indeed the order of the output does not match the order of declaration of the enumeration's values in this case.
+
+There are overloads of `TrialsApi.choose` that take each choice as a separate argument, or as an array (this was used above) or as an `Iterable`.
+
+So if we want to test a system with small primes as inputs and can't be bothered to Google for the Sieve of Eratosthenes, we simply set out our primes explicitly:
+
+```java
+Trials
+        .api()
+        .choose(1, 3, 5, 7, 11, 13, 17, 19, 23)
+        .withLimit(10)
+        .supplyTo(System.out::println);
+
+```
+
+How about mixing up different kinds of trials that produce the same _type_ of test case, but in different ways? Let's say we have a system under test that deals with any old integer, but we suspect that small values might be a problem, so we want to make sure we've covered a small range, say 1 to 10 while dipping in to a wider pool of numbers that might get quite large. We could just give Americium a very large limit, cross our fingers and hope that we cover 1 to 10 in the process, but there is a much better way ... alternation.
+
+```java
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.sageserpent.americium.java.Trials.api;
+
+final Trials<Integer> anyOldIntegers = api().integers();
+
+final Trials<Integer> veryImportantIntegers = api().choose(
+        Stream.iterate(1, x -> 1 + x)
+              .limit(10)
+              .collect(Collectors.toList()));
+
+final Trials<Integer> trials =
+        api().alternate(anyOldIntegers, veryImportantIntegers);
+
+trials.withLimit(20).supplyTo(System.out::println);
+```
+
+This yields:
+
+```
+7
+-1955330156
+4
+1531869968
+3
+1806495736
+5
+1987104774
+1840758034
+8
+2
+203172046
+1
+-1111845053
+1658077352
+10
+6
+-685852310
+-1423277862
+9
+```
+
+See how the important numbers from 1 to 10 were all covered, but we had some general ones thrown in.
+
+Finally, alternation is handy when we want to mix in some special case value, often a sentinel value, into the trials. This is like alternating between some trials and a choice of one value, but there is shorthand for this that is better:
+
+```java
+final Trials<Integer> anyOldNumberOfBytes = api().nonNegativeIntegers();
+
+final Trials<Integer> noBytesSentinel = api().only(-1);
+
+final Trials<Integer> trials =
+        api().alternate(anyOldNumberOfBytes, noBytesSentinel);
+
+trials.withLimit(10).supplyTo(System.out::println);
+```
+
+This prints:
+
+```
+-1
+-1057358237
+2128104420
+637157859
+1272878179
+445778542
+633033882
+1885261282
+273004927
+-1367005977
+```
+
+Now we can ask `TrialsApi` to yield arbitrary values via its convenience methods, specify our own choice of values, alternate between different ways of producing the same kind of test case and throw in a special case too.
+
+One last thing - we can weight both choices and alternation, let's see this with alternation:
+
+```java
+final Trials<Integer> evens = api().choose(Stream.iterate(0, x -> 2 + x).limit(20).collect(
+        Collectors.toList()));
+
+final Trials<Integer> odds = api().choose(Stream.iterate(1, x -> 2 + x).limit(20).collect(
+        Collectors.toList()));
+
+final Trials<Integer> trials =
+        api().alternateWithWeights(Map.entry(1, evens), Map.entry(2, odds));
+
+
+trials.withLimit(10).supplyTo(System.out::println);
+```
+
+Observe that odd numbers occur roughly twice as often as even numbers:
+
+```
+12
+17
+19
+3
+24
+3
+19
+20
+5
+31
+```
+
+Those pesky eagle-eyed readers will note that 19 is duplicated in the output! This is subtle, it comes down to Americium not actually enforcing uniqueness of _test cases_ for reasons that are explained in the design and implementation topic - rather it enforces uniqueness in the manner in which a test case was internally derived. That uniqueness actually holds because the weighting is implemented as if the weighted alternatives were duplicated in proportion to their weights - this means that the implementation doesn't try to unfairly 'cycle' weighted alternatives to make up the frequency, instead it picks fairly (and randomly) between all of the duplicates taken together across all the alternatives.
+
+There is a `TrialsApi.chooseWithWeights` to complement `TrialsApi.alternateWithWeights`, try it out.
+
+The generation of the even and odd numbers can be simplified and made more powerful - on to the next section...
+
+***
+Next topic: [Building up test cases...]({% link docs/wiki-content/building-up-test-cases.md %})


### PR DESCRIPTION
I have successfully migrated the content from the Americium Wiki to a new section in the microsite. 

Key improvements and actions taken:
- **New Section**: Added a `Wiki Content` section under `docs/wiki-content/` that is easily navigable from the sidebar.
- **Content Adaptation**: Each of the 15 Wiki pages was converted to Markdown with proper Jekyll front matter (`layout`, `title`, `parent`, `nav_order`).
- **Link Correction**: Systematically updated all internal Wiki links to use the `{% link %}` tag for reliable cross-referencing within the Jekyll site.
- **Visual Style**: Applied the "Just the Docs" formatting, including table of contents and styling classes for subtitles.
- **Image Fixes**: Converted GitHub blob URLs to raw image URLs to ensure screenshots render correctly.
- **Parity**: Maintained the factual content and examples from the original Wiki as requested.

The new section allows for a side-by-side comparison with the existing documentation while preserving the original technical depth and examples.

---
*PR created automatically by Jules for task [3832633911161577823](https://jules.google.com/task/3832633911161577823) started by @sageserpent-open*