### PR TITLE
Add non-empty collection methods to Trials APIs

### DIFF
--- a/core-library/src/main/java/com/sageserpent/americium/java/CharacterTrials.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/CharacterTrials.java
@@ -5,6 +5,10 @@ public interface CharacterTrials extends Trials<Character> {
         return collections(Builder::stringBuilder);
     }
 
+    default Trials<String> nonEmptyStrings() {
+        return nonEmptyCollections(Builder::stringBuilder);
+    }
+
     default Trials<String> stringsOfSize(int size) {
         return collectionsOfSize(size, Builder::stringBuilder);
     }

--- a/core-library/src/main/java/com/sageserpent/americium/java/Trials.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/Trials.java
@@ -142,19 +142,47 @@ public interface Trials<Case> extends
     <Collection> Trials<Collection> collections(
             Supplier<Builder<Case, Collection>> builderFactory);
 
+    /**
+     * Transform this to a trials of non-empty collection, where
+     * {@code Collection} is some kind of collection that can be built from
+     * elements of type {@code Case} by a {@link Builder}.
+     *
+     * @param builderFactory A {@link Supplier} that should construct a
+     *                       *fresh* instance of a {@link Builder}.
+     * @param <Collection>   Any kind of collection that can take an
+     *                       arbitrary number of elements of type {@code Case}.
+     * @return A {@link Trials} instance that yields non-empty collections.
+     */
+    <Collection> Trials<Collection> nonEmptyCollections(
+            Supplier<Builder<Case, Collection>> builderFactory);
+
     // Convenience methods that enable supply of Guava collection cases...
 
     Trials<ImmutableList<Case>> immutableLists();
 
+    Trials<ImmutableList<Case>> nonEmptyImmutableLists();
+
     Trials<ImmutableSet<Case>> immutableSets();
 
+    Trials<ImmutableSet<Case>> nonEmptyImmutableSets();
+
     Trials<ImmutableSortedSet<Case>> immutableSortedSets(
+            final Comparator<Case> elementComparator);
+
+    Trials<ImmutableSortedSet<Case>> nonEmptyImmutableSortedSets(
             final Comparator<Case> elementComparator);
 
     <Value> Trials<ImmutableMap<Case, Value>> immutableMaps(
             final Trials<Value> values);
 
+    <Value> Trials<ImmutableMap<Case, Value>> nonEmptyImmutableMaps(
+            final Trials<Value> values);
+
     <Value> Trials<ImmutableSortedMap<Case, Value>> immutableSortedMaps(
+            final Comparator<Case> elementComparator,
+            final Trials<Value> values);
+
+    <Value> Trials<ImmutableSortedMap<Case, Value>> nonEmptyImmutableSortedMaps(
             final Comparator<Case> elementComparator,
             final Trials<Value> values);
 

--- a/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
@@ -160,6 +160,10 @@ public interface TrialsApi {
             Iterable<Trials<Element>> iterableOfTrials,
             Supplier<Builder<Element, Collection>> builderFactory);
 
+    <Element, Collection> Trials<Collection> nonEmptyCollections(
+            Iterable<Trials<Element>> iterableOfTrials,
+            Supplier<Builder<Element, Collection>> builderFactory);
+
     /**
      * This is for advanced usage, where there is a need to control how
      * trials instances are formulated to avoid hitting the complexity limit,
@@ -290,6 +294,8 @@ public interface TrialsApi {
 
     CharacterTrials characters(char lowerBound, char upperBound,
                                char shrinkageTarget);
+
+    Trials<String> nonEmptyStrings();
 
     Trials<Instant> instants();
 

--- a/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
@@ -160,10 +160,6 @@ public interface TrialsApi {
             Iterable<Trials<Element>> iterableOfTrials,
             Supplier<Builder<Element, Collection>> builderFactory);
 
-    <Element, Collection> Trials<Collection> nonEmptyCollections(
-            Iterable<Trials<Element>> iterableOfTrials,
-            Supplier<Builder<Element, Collection>> builderFactory);
-
     /**
      * This is for advanced usage, where there is a need to control how
      * trials instances are formulated to avoid hitting the complexity limit,

--- a/core-library/src/main/scala/com/sageserpent/americium/Trials.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/Trials.scala
@@ -202,14 +202,6 @@ trait Trials[+Case]
       factory: Factory[Case, Collection]
   ): Trials[Collection]
 
-  /** @deprecated
-    *   Use [[nonEmptyCollections]] instead.
-    */
-  @deprecated("Use 'nonEmptyCollections' instead.")
-  def nonEmptySeveral[Collection](implicit
-      factory: Factory[Case, Collection]
-  ): Trials[Collection] = nonEmptyCollections
-
   def lists: Trials[List[Case]]
 
   def nonEmptyLists: Trials[List[Case]]

--- a/core-library/src/main/scala/com/sageserpent/americium/Trials.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/Trials.scala
@@ -63,7 +63,9 @@ object Trials {
 
   implicit class CharacterTrialsSyntax(val characterTrials: Trials[Char])
       extends AnyVal {
-    def strings: Trials[String] = characterTrials.several
+    def strings: Trials[String] = characterTrials.collections
+
+    def nonEmptyStrings: Trials[String] = characterTrials.nonEmptyCollections
 
     def stringsOfSize(size: Int): Trials[String] =
       characterTrials.lotsOfSize(size)
@@ -172,15 +174,55 @@ trait Trials[+Case]
     * @return
     *   A [[Trials]] instance that yields {@code Collection} instances.
     */
-  def several[Collection](implicit
+  def collections[Collection](implicit
       factory: Factory[Case, Collection]
   ): Trials[Collection]
 
+  /** @deprecated
+    *   Use [[collections]] instead.
+    */
+  @deprecated("Use 'collections' instead.")
+  def several[Collection](implicit
+      factory: Factory[Case, Collection]
+  ): Trials[Collection] = collections
+
+  /** Transform this to a trials of non-empty collection, where
+    * {@code Collection} is some kind of collection that can be built from
+    * elements of type {@code Case} by a [[Factory]].
+    *
+    * @param factory
+    *   A [[Factory]] that can build a [[Collection]] .
+    * @tparam Collection
+    *   Any kind of collection that can take an arbitrary number of elements of
+    *   type {@code Case} .
+    * @return
+    *   A [[Trials]] instance that yields non-empty [[Collection]] instances.
+    */
+  def nonEmptyCollections[Collection](implicit
+      factory: Factory[Case, Collection]
+  ): Trials[Collection]
+
+  /** @deprecated
+    *   Use [[nonEmptyCollections]] instead.
+    */
+  @deprecated("Use 'nonEmptyCollections' instead.")
+  def nonEmptySeveral[Collection](implicit
+      factory: Factory[Case, Collection]
+  ): Trials[Collection] = nonEmptyCollections
+
   def lists: Trials[List[Case]]
+
+  def nonEmptyLists: Trials[List[Case]]
 
   def sets: Trials[Set[Case @uncheckedVariance]]
 
+  def nonEmptySets: Trials[Set[Case @uncheckedVariance]]
+
   def sortedSets(implicit
+      ordering: Ordering[Case @uncheckedVariance]
+  ): Trials[SortedSet[Case @uncheckedVariance]]
+
+  def nonEmptySortedSets(implicit
       ordering: Ordering[Case @uncheckedVariance]
   ): Trials[SortedSet[Case @uncheckedVariance]]
 
@@ -188,7 +230,15 @@ trait Trials[+Case]
       values: Trials[Value]
   ): Trials[Map[Case @uncheckedVariance, Value]]
 
+  def nonEmptyMaps[Value](
+      values: Trials[Value]
+  ): Trials[Map[Case @uncheckedVariance, Value]]
+
   def sortedMaps[Value](values: Trials[Value])(implicit
+      ordering: Ordering[Case @uncheckedVariance]
+  ): Trials[SortedMap[Case @uncheckedVariance, Value]]
+
+  def nonEmptySortedMaps[Value](values: Trials[Value])(implicit
       ordering: Ordering[Case @uncheckedVariance]
   ): Trials[SortedMap[Case @uncheckedVariance, Value]]
 

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -300,6 +300,8 @@ trait TrialsApi {
 
   def strings: Trials[String]
 
+  def nonEmptyStrings: Trials[String]
+
   /** Produce a trials instance whose cases can be used to permute elements of
     * indexed collections, or as permutations of integers in their own right.
     *

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
@@ -387,8 +387,12 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
     shrinkageTarget.toEpochMilli
   ).map(Instant.ofEpochMilli)
 
-  override def strings: TrialsImplementation[String] = {
-    characters.several[String]
+  override def strings: ScalaTrials[String] = {
+    characters.collections[String]
+  }
+
+  override def nonEmptyStrings: ScalaTrials[String] = {
+    characters.nonEmptyCollections[String]
   }
 
   override def characters: TrialsImplementation[Char] =

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
@@ -520,7 +520,7 @@ case class TrialsImplementation[Case](
           partialResult.foreach(builder.add)
           builder.build()
         },
-        flatMap(item =>
+        flatMap((item: Case) =>
           addItems(item :: partialResult).scalaTrials: ScalaTrials[Collection]
         ).scalaTrials.asInstanceOf[TrialsImplementation[Collection]]
       )
@@ -535,7 +535,7 @@ case class TrialsImplementation[Case](
   override def nonEmptySeveralImplementation[Collection](
       builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
   ): JavaTrials[Collection] =
-    flatMap(item =>
+    flatMap((item: Case) =>
       severalImplementation(() => {
         val builder = builderFactory.get()
         builder.add(item)
@@ -574,10 +574,10 @@ case class TrialsImplementation[Case](
             builder.build()
           }
         else
-          flatMap(item =>
+          flatMap((item: Case) =>
             (scalaApi
               .resetComplexity(complexity): ScalaTrials[Unit])
-              .flatMap(_ =>
+              .flatMap((_: Unit) =>
                 addItems(
                   numberOfItems - 1,
                   item :: partialResult

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
@@ -26,7 +26,8 @@ import com.sageserpent.americium.java.{
   RecipeCouldNotBeReproducedException,
   TestIntegrationContext,
   TrialsScaffolding as JavaTrialsScaffolding,
-  TrialsSkeletalImplementation as JavaTrialsSkeletalImplementation
+  TrialsSkeletalImplementation as JavaTrialsSkeletalImplementation,
+  Trials as JavaTrials
 }
 import com.sageserpent.americium.storage.TrialsReproductionStorage
 import com.sageserpent.americium.storage.TrialsReproductionStorage.RecipeData
@@ -469,39 +470,82 @@ case class TrialsImplementation[Case](
       }
     }
 
+  override def collections[Collection](implicit
+      factory: scala.collection.Factory[Case, Collection]
+  ): ScalaTrials[Collection] = severalImplementation(() =>
+    new Builder[Case, Collection] {
+      private val underlyingBuilder = factory.newBuilder
+
+      override def add(caze: Case): Unit = {
+        underlyingBuilder += caze
+      }
+
+      override def build(): Collection = underlyingBuilder.result()
+    }
+  ).scalaTrials
+
   override def several[Collection](implicit
       factory: scala.collection.Factory[Case, Collection]
-  ): TrialsImplementation[Collection] = several(new Builder[Case, Collection] {
-    private val underlyingBuilder = factory.newBuilder
+  ): ScalaTrials[Collection] = collections(factory)
 
-    override def add(caze: Case): Unit = {
-      underlyingBuilder += caze
+  override def nonEmptyCollections[Collection](implicit
+      factory: scala.collection.Factory[Case, Collection]
+  ): ScalaTrials[Collection] = nonEmptySeveralImplementation(() =>
+    new Builder[Case, Collection] {
+      private val underlyingBuilder = factory.newBuilder
+
+      override def add(caze: Case): Unit = {
+        underlyingBuilder += caze
+      }
+
+      override def build(): Collection = underlyingBuilder.result()
     }
+  ).scalaTrials
 
-    override def build(): Collection = underlyingBuilder.result()
-  })
+  override def nonEmptySeveral[Collection](implicit
+      factory: scala.collection.Factory[Case, Collection]
+  ): ScalaTrials[Collection] = nonEmptyCollections(factory)
 
-  protected override def several[Collection](
-      builderFactory: => Builder[Case, Collection]
-  ): TrialsImplementation[Collection] = {
+  override def collections[Collection](
+      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection] = severalImplementation(builderFactory)
+
+  override def severalImplementation[Collection](
+      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection] = {
     def addItems(partialResult: List[Case]): TrialsImplementation[Collection] =
       scalaApi.alternate(
         scalaApi.only {
-          val builder = builderFactory
-          partialResult.foreach(builder add _)
+          val builder = builderFactory.get()
+          partialResult.foreach(builder.add)
           builder.build()
         },
         flatMap(item =>
-          addItems(item :: partialResult): ScalaTrials[Collection]
-        )
+          addItems(item :: partialResult).scalaTrials: ScalaTrials[Collection]
+        ).scalaTrials.asInstanceOf[TrialsImplementation[Collection]]
       )
 
     addItems(Nil)
   }
 
+  override def nonEmptyCollections[Collection](
+      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection] = nonEmptySeveralImplementation(builderFactory)
+
+  override def nonEmptySeveralImplementation[Collection](
+      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection] =
+    flatMap(item =>
+      severalImplementation(() => {
+        val builder = builderFactory.get()
+        builder.add(item)
+        builder
+      }).scalaTrials
+    ).javaTrials
+
   override def lotsOfSize[Collection](size: Int)(implicit
       factory: collection.Factory[Case, Collection]
-  ): TrialsImplementation[Collection] = lotsOfSize(
+  ): ScalaTrials[Collection] = lotsOfSize(
     size,
     new Builder[Case, Collection] {
       private val underlyingBuilder = factory.newBuilder

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
@@ -472,7 +472,7 @@ case class TrialsImplementation[Case](
 
   override def collections[Collection](implicit
       factory: scala.collection.Factory[Case, Collection]
-  ): ScalaTrials[Collection] = severalImplementation(() =>
+  ): TrialsImplementation[Collection] = severalImplementation(
     new Builder[Case, Collection] {
       private val underlyingBuilder = factory.newBuilder
 
@@ -482,15 +482,15 @@ case class TrialsImplementation[Case](
 
       override def build(): Collection = underlyingBuilder.result()
     }
-  ).scalaTrials
+  )
 
   override def several[Collection](implicit
       factory: scala.collection.Factory[Case, Collection]
-  ): ScalaTrials[Collection] = collections(factory)
+  ): TrialsImplementation[Collection] = collections(factory)
 
   override def nonEmptyCollections[Collection](implicit
       factory: scala.collection.Factory[Case, Collection]
-  ): ScalaTrials[Collection] = nonEmptySeveralImplementation(() =>
+  ): TrialsImplementation[Collection] = nonEmptySeveralImplementation(
     new Builder[Case, Collection] {
       private val underlyingBuilder = factory.newBuilder
 
@@ -500,29 +500,26 @@ case class TrialsImplementation[Case](
 
       override def build(): Collection = underlyingBuilder.result()
     }
-  ).scalaTrials
-
-  override def nonEmptySeveral[Collection](implicit
-      factory: scala.collection.Factory[Case, Collection]
-  ): ScalaTrials[Collection] = nonEmptyCollections(factory)
+  )
 
   override def collections[Collection](
       builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection] = severalImplementation(builderFactory)
+  ): TrialsImplementation[Collection] =
+    severalImplementation(builderFactory.get())
 
   override def severalImplementation[Collection](
-      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection] = {
+      builderFactory: => Builder[Case, Collection]
+  ): TrialsImplementation[Collection] = {
     def addItems(partialResult: List[Case]): TrialsImplementation[Collection] =
       scalaApi.alternate(
         scalaApi.only {
-          val builder = builderFactory.get()
+          val builder = builderFactory
           partialResult.foreach(builder.add)
           builder.build()
         },
         flatMap((item: Case) =>
-          addItems(item :: partialResult).scalaTrials: ScalaTrials[Collection]
-        ).scalaTrials.asInstanceOf[TrialsImplementation[Collection]]
+          addItems(item :: partialResult)
+        )
       )
 
     addItems(Nil)
@@ -530,18 +527,19 @@ case class TrialsImplementation[Case](
 
   override def nonEmptyCollections[Collection](
       builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection] = nonEmptySeveralImplementation(builderFactory)
+  ): TrialsImplementation[Collection] =
+    nonEmptySeveralImplementation(builderFactory.get())
 
   override def nonEmptySeveralImplementation[Collection](
-      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection] =
+      builderFactory: => Builder[Case, Collection]
+  ): TrialsImplementation[Collection] =
     flatMap((item: Case) =>
-      severalImplementation(() => {
-        val builder = builderFactory.get()
+      severalImplementation({
+        val builder = builderFactory
         builder.add(item)
         builder
-      }).scalaTrials
-    ).javaTrials
+      })
+    )
 
   override def lotsOfSize[Collection](size: Int)(implicit
       factory: collection.Factory[Case, Collection]

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsSkeletalImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsSkeletalImplementation.scala
@@ -71,7 +71,11 @@ trait TrialsSkeletalImplementation[Case] extends ScalaTrials[Case] {
       factory: collection.Factory[Case, Container]
   ): ScalaTrials[Container]
 
-  override def nonEmptySeveral[Container](implicit
+  /** @deprecated
+    *   Use [[nonEmptyCollections]] instead.
+    */
+  @deprecated("Use 'nonEmptyCollections' instead.")
+  def nonEmptySeveral[Container](implicit
       factory: collection.Factory[Case, Container]
   ): ScalaTrials[Container] = nonEmptyCollections(factory)
 

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsSkeletalImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsSkeletalImplementation.scala
@@ -59,39 +59,73 @@ trait TrialsSkeletalImplementation[Case] extends ScalaTrials[Case] {
   override def options: TrialsImplementation[Option[Case]] =
     scalaApi.alternate(scalaApi.only(None), this.map(Some.apply[Case]))
 
+  override def collections[Container](implicit
+      factory: collection.Factory[Case, Container]
+  ): ScalaTrials[Container]
+
   override def several[Container](implicit
       factory: collection.Factory[Case, Container]
-  ): TrialsSkeletalImplementation[Container]
+  ): ScalaTrials[Container] = collections(factory)
 
-  override def lists: TrialsSkeletalImplementation[List[Case]] = several
+  override def nonEmptyCollections[Container](implicit
+      factory: collection.Factory[Case, Container]
+  ): ScalaTrials[Container]
 
-  override def sets: TrialsSkeletalImplementation[Set[Case]] = several
+  override def nonEmptySeveral[Container](implicit
+      factory: collection.Factory[Case, Container]
+  ): ScalaTrials[Container] = nonEmptyCollections(factory)
+
+  override def lists: ScalaTrials[List[Case]] = collections
+
+  override def nonEmptyLists: ScalaTrials[List[Case]] = nonEmptyCollections
+
+  override def sets: ScalaTrials[Set[Case]] = collections
+
+  override def nonEmptySets: ScalaTrials[Set[Case]] = nonEmptyCollections
 
   override def sortedSets(implicit
       ordering: Ordering[Case]
-  ): TrialsSkeletalImplementation[SortedSet[Case]] =
+  ): ScalaTrials[SortedSet[Case]] =
     lists.map(SortedSet.from[Case](_)(ordering))
+
+  override def nonEmptySortedSets(implicit
+      ordering: Ordering[Case]
+  ): ScalaTrials[SortedSet[Case]] =
+    nonEmptyLists.map(SortedSet.from[Case](_)(ordering))
 
   override def maps[Value](
       values: ScalaTrials[Value]
-  ): TrialsSkeletalImplementation[Map[Case, Value]] =
-    flatMap(key => values.map(key -> _)).several[Map[Case, Value]]
+  ): ScalaTrials[Map[Case, Value]] =
+    flatMap(key => values.map(key -> _)).collections[Map[Case, Value]]
+
+  override def nonEmptyMaps[Value](
+      values: ScalaTrials[Value]
+  ): ScalaTrials[Map[Case, Value]] =
+    flatMap(key => values.map(key -> _)).nonEmptyCollections[Map[Case, Value]]
 
   override def sortedMaps[Value](
       values: ScalaTrials[Value]
   )(implicit
       ordering: Ordering[Case]
-  ): TrialsSkeletalImplementation[SortedMap[Case, Value]] =
+  ): ScalaTrials[SortedMap[Case, Value]] =
     flatMap(key => values.map(key -> _)).lists
+      .map(SortedMap.from[Case, Value](_)(ordering))
+
+  override def nonEmptySortedMaps[Value](
+      values: ScalaTrials[Value]
+  )(implicit
+      ordering: Ordering[Case]
+  ): ScalaTrials[SortedMap[Case, Value]] =
+    flatMap(key => values.map(key -> _)).nonEmptyLists
       .map(SortedMap.from[Case, Value](_)(ordering))
 
   override def lotsOfSize[Collection](size: Int)(implicit
       factory: collection.Factory[Case, Collection]
-  ): TrialsSkeletalImplementation[Collection]
+  ): ScalaTrials[Collection]
 
   override def listsOfSize(
       size: Int
-  ): TrialsSkeletalImplementation[List[Case]] = lotsOfSize(
+  ): ScalaTrials[List[Case]] = lotsOfSize(
     size
   )
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
@@ -132,6 +132,28 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
           }
       )
 
+  override def nonEmptyCollections[Case, Collection](
+      iterableOfTrials: JavaIterable[JavaTrials[Case]],
+      builderFactory: Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection] =
+    // NASTY HACK: make a throwaway trials of type `TrialsImplementation` to
+    // act as a springboard to flatmap the 'real' result into the correct
+    // type.
+    scalaApi
+      .only(())
+      .flatMap((_: Unit) =>
+        scalaApi
+          .sequences[Case, List](
+            iterableOfTrials.asScala.map(_.scalaTrials).toList
+          )
+          .filter(_.nonEmpty)
+          .map { sequence =>
+            val builder = builderFactory.get()
+            sequence.foreach(builder.add)
+            builder.build()
+          }
+      )
+
   override def collections[Case, Collection](
       iterableOfTrials: JavaIterable[JavaTrials[Case]],
       builderFactory: Supplier[Builder[Case, Collection]]
@@ -337,6 +359,9 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
 
   override def strings(): JavaTrials[String] =
     characters().strings
+
+  override def nonEmptyStrings(): JavaTrials[String] =
+    characters().nonEmptyStrings()
 
   override def characters(): CharacterTrials =
     DelegatingTrials.delegateTo(

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
@@ -132,28 +132,6 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
           }
       )
 
-  override def nonEmptyCollections[Case, Collection](
-      iterableOfTrials: JavaIterable[JavaTrials[Case]],
-      builderFactory: Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection] =
-    // NASTY HACK: make a throwaway trials of type `TrialsImplementation` to
-    // act as a springboard to flatmap the 'real' result into the correct
-    // type.
-    scalaApi
-      .only(())
-      .flatMap((_: Unit) =>
-        scalaApi
-          .sequences[Case, List](
-            iterableOfTrials.asScala.map(_.scalaTrials).toList
-          )
-          .filter(_.nonEmpty)
-          .map { sequence =>
-            val builder = builderFactory.get()
-            sequence.foreach(builder.add)
-            builder.build()
-          }
-      )
-
   override def collections[Case, Collection](
       iterableOfTrials: JavaIterable[JavaTrials[Case]],
       builderFactory: Supplier[Builder[Case, Collection]]

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
@@ -192,7 +192,7 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       values: JavaTrials[Value]
   ): JavaTrials[ImmutableMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .severalImplementation(() =>
+      .collections(() =>
         new Builder[(Case, Value), ImmutableMap[Case, Value]] {
           val accumulator: JavaMap[Case, Value] =
             new JavaHashMap()
@@ -210,7 +210,7 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       values: JavaTrials[Value]
   ): JavaTrials[ImmutableMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .nonEmptySeveralImplementation(() =>
+      .nonEmptyCollections(() =>
         new Builder[(Case, Value), ImmutableMap[Case, Value]] {
           val accumulator: JavaMap[Case, Value] =
             new JavaHashMap()
@@ -229,7 +229,7 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       values: JavaTrials[Value]
   ): JavaTrials[ImmutableSortedMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .nonEmptySeveralImplementation(() =>
+      .nonEmptyCollections(() =>
         new Builder[
           (Case, Value),
           ImmutableSortedMap[Case, Value]
@@ -251,7 +251,7 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       values: JavaTrials[Value]
   ): JavaTrials[ImmutableSortedMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .severalImplementation(() =>
+      .collections(() =>
         new Builder[
           (Case, Value),
           ImmutableSortedMap[Case, Value]

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
@@ -70,129 +70,117 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
   protected def lotsOfSize[Collection](
       size: Int,
       builderFactory: => Builder[Case, Collection]
-  ): TrialsSkeletalImplementation[Collection]
+  ): TrialsImplementation[Collection]
 
   protected def severalImplementation[Collection](
-      builderFactory: Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection]
+      builderFactory: => Builder[Case, Collection]
+  ): TrialsImplementation[Collection]
 
   protected def nonEmptySeveralImplementation[Collection](
-      builderFactory: Supplier[Builder[Case, Collection]]
-  ): JavaTrials[Collection]
+      builderFactory: => Builder[Case, Collection]
+  ): TrialsImplementation[Collection]
 
   override def collections[Collection](
       builderFactory: Supplier[
         Builder[Case, Collection]
       ]
-  ): JavaTrials[Collection] =
-    severalImplementation(builderFactory)
+  ): TrialsImplementation[Collection] =
+    severalImplementation(builderFactory.get())
 
   override def nonEmptyCollections[Collection](
       builderFactory: Supplier[
         Builder[Case, Collection]
       ]
-  ): JavaTrials[Collection] =
-    nonEmptySeveralImplementation(builderFactory)
+  ): TrialsImplementation[Collection] =
+    nonEmptySeveralImplementation(builderFactory.get())
 
   override def immutableLists()
-      : JavaTrials[ImmutableList[Case]] =
-    severalImplementation(() =>
-      new Builder[Case, ImmutableList[Case]] {
-        private val underlyingBuilder = ImmutableList.builder[Case]()
+      : TrialsImplementation[ImmutableList[Case]] =
+    severalImplementation(new Builder[Case, ImmutableList[Case]] {
+      private val underlyingBuilder = ImmutableList.builder[Case]()
 
-        override def add(caze: Case): Unit = {
-          underlyingBuilder.add(caze)
-        }
-
-        override def build(): ImmutableList[Case] =
-          underlyingBuilder.build()
+      override def add(caze: Case): Unit = {
+        underlyingBuilder.add(caze)
       }
-    )
+
+      override def build(): ImmutableList[Case] =
+        underlyingBuilder.build()
+    })
 
   override def nonEmptyImmutableLists()
-      : JavaTrials[ImmutableList[Case]] =
-    nonEmptySeveralImplementation(() =>
-      new Builder[Case, ImmutableList[Case]] {
-        private val underlyingBuilder = ImmutableList.builder[Case]()
+      : TrialsImplementation[ImmutableList[Case]] =
+    nonEmptySeveralImplementation(new Builder[Case, ImmutableList[Case]] {
+      private val underlyingBuilder = ImmutableList.builder[Case]()
 
-        override def add(caze: Case): Unit = {
-          underlyingBuilder.add(caze)
-        }
-
-        override def build(): ImmutableList[Case] =
-          underlyingBuilder.build()
+      override def add(caze: Case): Unit = {
+        underlyingBuilder.add(caze)
       }
-    )
+
+      override def build(): ImmutableList[Case] =
+        underlyingBuilder.build()
+    })
 
   override def immutableSets()
-      : JavaTrials[ImmutableSet[Case]] =
-    severalImplementation(() =>
-      new Builder[Case, ImmutableSet[Case]] {
-        private val underlyingBuilder = ImmutableSet.builder[Case]()
+      : TrialsImplementation[ImmutableSet[Case]] =
+    severalImplementation(new Builder[Case, ImmutableSet[Case]] {
+      private val underlyingBuilder = ImmutableSet.builder[Case]()
 
-        override def add(caze: Case): Unit = {
-          underlyingBuilder.add(caze)
-        }
-
-        override def build(): ImmutableSet[Case] =
-          underlyingBuilder.build()
+      override def add(caze: Case): Unit = {
+        underlyingBuilder.add(caze)
       }
-    )
+
+      override def build(): ImmutableSet[Case] =
+        underlyingBuilder.build()
+    })
 
   override def nonEmptyImmutableSets()
-      : JavaTrials[ImmutableSet[Case]] =
-    nonEmptySeveralImplementation(() =>
-      new Builder[Case, ImmutableSet[Case]] {
-        private val underlyingBuilder = ImmutableSet.builder[Case]()
+      : TrialsImplementation[ImmutableSet[Case]] =
+    nonEmptySeveralImplementation(new Builder[Case, ImmutableSet[Case]] {
+      private val underlyingBuilder = ImmutableSet.builder[Case]()
 
-        override def add(caze: Case): Unit = {
-          underlyingBuilder.add(caze)
-        }
-
-        override def build(): ImmutableSet[Case] =
-          underlyingBuilder.build()
+      override def add(caze: Case): Unit = {
+        underlyingBuilder.add(caze)
       }
-    )
+
+      override def build(): ImmutableSet[Case] =
+        underlyingBuilder.build()
+    })
 
   override def immutableSortedSets(
       elementComparator: Comparator[Case]
-  ): JavaTrials[ImmutableSortedSet[Case]] =
-    severalImplementation(() =>
-      new Builder[Case, ImmutableSortedSet[Case]] {
-        private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
-          new ImmutableSortedSet.Builder(elementComparator)
+  ): TrialsImplementation[ImmutableSortedSet[Case]] =
+    severalImplementation(new Builder[Case, ImmutableSortedSet[Case]] {
+      private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
+        new ImmutableSortedSet.Builder(elementComparator)
 
-        override def add(caze: Case): Unit = {
-          underlyingBuilder.add(caze)
-        }
-
-        override def build(): ImmutableSortedSet[Case] =
-          underlyingBuilder.build()
+      override def add(caze: Case): Unit = {
+        underlyingBuilder.add(caze)
       }
-    )
+
+      override def build(): ImmutableSortedSet[Case] =
+        underlyingBuilder.build()
+    })
 
   override def nonEmptyImmutableSortedSets(
       elementComparator: Comparator[Case]
-  ): JavaTrials[ImmutableSortedSet[Case]] =
-    nonEmptySeveralImplementation(() =>
-      new Builder[Case, ImmutableSortedSet[Case]] {
-        private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
-          new ImmutableSortedSet.Builder(elementComparator)
+  ): TrialsImplementation[ImmutableSortedSet[Case]] =
+    nonEmptySeveralImplementation(new Builder[Case, ImmutableSortedSet[Case]] {
+      private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
+        new ImmutableSortedSet.Builder(elementComparator)
 
-        override def add(caze: Case): Unit = {
-          underlyingBuilder.add(caze)
-        }
-
-        override def build(): ImmutableSortedSet[Case] =
-          underlyingBuilder.build()
+      override def add(caze: Case): Unit = {
+        underlyingBuilder.add(caze)
       }
-    )
+
+      override def build(): ImmutableSortedSet[Case] =
+        underlyingBuilder.build()
+    })
 
   override def immutableMaps[Value](
       values: JavaTrials[Value]
-  ): JavaTrials[ImmutableMap[Case, Value]] =
+  ): TrialsImplementation[ImmutableMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .collections(() =>
+      .severalImplementation(
         new Builder[(Case, Value), ImmutableMap[Case, Value]] {
           val accumulator: JavaMap[Case, Value] =
             new JavaHashMap()
@@ -208,9 +196,9 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
 
   override def nonEmptyImmutableMaps[Value](
       values: JavaTrials[Value]
-  ): JavaTrials[ImmutableMap[Case, Value]] =
+  ): TrialsImplementation[ImmutableMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .nonEmptyCollections(() =>
+      .nonEmptySeveralImplementation(
         new Builder[(Case, Value), ImmutableMap[Case, Value]] {
           val accumulator: JavaMap[Case, Value] =
             new JavaHashMap()
@@ -227,9 +215,9 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
   override def nonEmptyImmutableSortedMaps[Value](
       elementComparator: Comparator[Case],
       values: JavaTrials[Value]
-  ): JavaTrials[ImmutableSortedMap[Case, Value]] =
+  ): TrialsImplementation[ImmutableSortedMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .nonEmptyCollections(() =>
+      .nonEmptySeveralImplementation(
         new Builder[
           (Case, Value),
           ImmutableSortedMap[Case, Value]
@@ -249,9 +237,9 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
   override def immutableSortedMaps[Value](
       elementComparator: Comparator[Case],
       values: JavaTrials[Value]
-  ): JavaTrials[ImmutableSortedMap[Case, Value]] =
+  ): TrialsImplementation[ImmutableSortedMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .collections(() =>
+      .severalImplementation(
         new Builder[
           (Case, Value),
           ImmutableSortedMap[Case, Value]
@@ -273,12 +261,12 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       builderFactory: Supplier[
         Builder[Case, Collection]
       ]
-  ): JavaTrials[Collection] =
+  ): TrialsImplementation[Collection] =
     lotsOfSize(size, builderFactory.get())
 
   override def immutableListsOfSize(
       size: Int
-  ): JavaTrials[ImmutableList[Case]] =
+  ): TrialsImplementation[ImmutableList[Case]] =
     lotsOfSize(
       size,
       new Builder[Case, ImmutableList[Case]] {

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
@@ -72,63 +72,127 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       builderFactory: => Builder[Case, Collection]
   ): TrialsSkeletalImplementation[Collection]
 
-  protected def several[Collection](
-      builderFactory: => Builder[Case, Collection]
-  ): TrialsSkeletalImplementation[Collection]
+  protected def severalImplementation[Collection](
+      builderFactory: Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection]
+
+  protected def nonEmptySeveralImplementation[Collection](
+      builderFactory: Supplier[Builder[Case, Collection]]
+  ): JavaTrials[Collection]
 
   override def collections[Collection](
       builderFactory: Supplier[
         Builder[Case, Collection]
       ]
-  ): TrialsSkeletalImplementation[Collection] =
-    several(builderFactory.get())
+  ): JavaTrials[Collection] =
+    severalImplementation(builderFactory)
+
+  override def nonEmptyCollections[Collection](
+      builderFactory: Supplier[
+        Builder[Case, Collection]
+      ]
+  ): JavaTrials[Collection] =
+    nonEmptySeveralImplementation(builderFactory)
 
   override def immutableLists()
-      : TrialsSkeletalImplementation[ImmutableList[Case]] =
-    several(new Builder[Case, ImmutableList[Case]] {
-      private val underlyingBuilder = ImmutableList.builder[Case]()
+      : JavaTrials[ImmutableList[Case]] =
+    severalImplementation(() =>
+      new Builder[Case, ImmutableList[Case]] {
+        private val underlyingBuilder = ImmutableList.builder[Case]()
 
-      override def add(caze: Case): Unit = {
-        underlyingBuilder.add(caze)
+        override def add(caze: Case): Unit = {
+          underlyingBuilder.add(caze)
+        }
+
+        override def build(): ImmutableList[Case] =
+          underlyingBuilder.build()
       }
+    )
 
-      override def build(): ImmutableList[Case] =
-        underlyingBuilder.build()
-    })
+  override def nonEmptyImmutableLists()
+      : JavaTrials[ImmutableList[Case]] =
+    nonEmptySeveralImplementation(() =>
+      new Builder[Case, ImmutableList[Case]] {
+        private val underlyingBuilder = ImmutableList.builder[Case]()
+
+        override def add(caze: Case): Unit = {
+          underlyingBuilder.add(caze)
+        }
+
+        override def build(): ImmutableList[Case] =
+          underlyingBuilder.build()
+      }
+    )
 
   override def immutableSets()
-      : TrialsSkeletalImplementation[ImmutableSet[Case]] =
-    several(new Builder[Case, ImmutableSet[Case]] {
-      private val underlyingBuilder = ImmutableSet.builder[Case]()
+      : JavaTrials[ImmutableSet[Case]] =
+    severalImplementation(() =>
+      new Builder[Case, ImmutableSet[Case]] {
+        private val underlyingBuilder = ImmutableSet.builder[Case]()
 
-      override def add(caze: Case): Unit = {
-        underlyingBuilder.add(caze)
+        override def add(caze: Case): Unit = {
+          underlyingBuilder.add(caze)
+        }
+
+        override def build(): ImmutableSet[Case] =
+          underlyingBuilder.build()
       }
+    )
 
-      override def build(): ImmutableSet[Case] =
-        underlyingBuilder.build()
-    })
+  override def nonEmptyImmutableSets()
+      : JavaTrials[ImmutableSet[Case]] =
+    nonEmptySeveralImplementation(() =>
+      new Builder[Case, ImmutableSet[Case]] {
+        private val underlyingBuilder = ImmutableSet.builder[Case]()
+
+        override def add(caze: Case): Unit = {
+          underlyingBuilder.add(caze)
+        }
+
+        override def build(): ImmutableSet[Case] =
+          underlyingBuilder.build()
+      }
+    )
 
   override def immutableSortedSets(
       elementComparator: Comparator[Case]
-  ): TrialsSkeletalImplementation[ImmutableSortedSet[Case]] =
-    several(new Builder[Case, ImmutableSortedSet[Case]] {
-      private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
-        new ImmutableSortedSet.Builder(elementComparator)
+  ): JavaTrials[ImmutableSortedSet[Case]] =
+    severalImplementation(() =>
+      new Builder[Case, ImmutableSortedSet[Case]] {
+        private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
+          new ImmutableSortedSet.Builder(elementComparator)
 
-      override def add(caze: Case): Unit = {
-        underlyingBuilder.add(caze)
+        override def add(caze: Case): Unit = {
+          underlyingBuilder.add(caze)
+        }
+
+        override def build(): ImmutableSortedSet[Case] =
+          underlyingBuilder.build()
       }
+    )
 
-      override def build(): ImmutableSortedSet[Case] =
-        underlyingBuilder.build()
-    })
+  override def nonEmptyImmutableSortedSets(
+      elementComparator: Comparator[Case]
+  ): JavaTrials[ImmutableSortedSet[Case]] =
+    nonEmptySeveralImplementation(() =>
+      new Builder[Case, ImmutableSortedSet[Case]] {
+        private val underlyingBuilder: ImmutableSortedSet.Builder[Case] =
+          new ImmutableSortedSet.Builder(elementComparator)
+
+        override def add(caze: Case): Unit = {
+          underlyingBuilder.add(caze)
+        }
+
+        override def build(): ImmutableSortedSet[Case] =
+          underlyingBuilder.build()
+      }
+    )
 
   override def immutableMaps[Value](
       values: JavaTrials[Value]
-  ): TrialsSkeletalImplementation[ImmutableMap[Case, Value]] =
+  ): JavaTrials[ImmutableMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .several(
+      .severalImplementation(() =>
         new Builder[(Case, Value), ImmutableMap[Case, Value]] {
           val accumulator: JavaMap[Case, Value] =
             new JavaHashMap()
@@ -142,12 +206,52 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
         }
       )
 
+  override def nonEmptyImmutableMaps[Value](
+      values: JavaTrials[Value]
+  ): JavaTrials[ImmutableMap[Case, Value]] =
+    flatMap(key => values.map(key -> _))
+      .nonEmptySeveralImplementation(() =>
+        new Builder[(Case, Value), ImmutableMap[Case, Value]] {
+          val accumulator: JavaMap[Case, Value] =
+            new JavaHashMap()
+
+          override def add(entry: (Case, Value)): Unit = {
+            accumulator.put(entry._1, entry._2)
+          }
+          override def build(): ImmutableMap[Case, Value] = {
+            ImmutableMap.copyOf(accumulator)
+          }
+        }
+      )
+
+  override def nonEmptyImmutableSortedMaps[Value](
+      elementComparator: Comparator[Case],
+      values: JavaTrials[Value]
+  ): JavaTrials[ImmutableSortedMap[Case, Value]] =
+    flatMap(key => values.map(key -> _))
+      .nonEmptySeveralImplementation(() =>
+        new Builder[
+          (Case, Value),
+          ImmutableSortedMap[Case, Value]
+        ] {
+          val accumulator: JavaMap[Case, Value] =
+            new JavaHashMap()
+
+          override def add(entry: (Case, Value)): Unit = {
+            accumulator.put(entry._1, entry._2)
+          }
+          override def build(): ImmutableSortedMap[Case, Value] = {
+            ImmutableSortedMap.copyOf(accumulator, elementComparator)
+          }
+        }
+      )
+
   override def immutableSortedMaps[Value](
       elementComparator: Comparator[Case],
       values: JavaTrials[Value]
-  ): TrialsSkeletalImplementation[ImmutableSortedMap[Case, Value]] =
+  ): JavaTrials[ImmutableSortedMap[Case, Value]] =
     flatMap(key => values.map(key -> _))
-      .several(
+      .severalImplementation(() =>
         new Builder[
           (Case, Value),
           ImmutableSortedMap[Case, Value]
@@ -169,12 +273,12 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
       builderFactory: Supplier[
         Builder[Case, Collection]
       ]
-  ): TrialsSkeletalImplementation[Collection] =
+  ): JavaTrials[Collection] =
     lotsOfSize(size, builderFactory.get())
 
   override def immutableListsOfSize(
       size: Int
-  ): TrialsSkeletalImplementation[ImmutableList[Case]] =
+  ): JavaTrials[ImmutableList[Case]] =
     lotsOfSize(
       size,
       new Builder[Case, ImmutableList[Case]] {

--- a/core-library/src/test/java/com/sageserpent/americium/java/NonEmptyCollectionsJavaTest.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/NonEmptyCollectionsJavaTest.java
@@ -1,0 +1,72 @@
+package com.sageserpent.americium.java;
+
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class NonEmptyCollectionsJavaTest {
+    private final TrialsApi api = Trials.api();
+    private final Trials<Integer> elementTrials = api.integers();
+
+    @Test
+    void nonEmptyCollectionsShouldYieldOnlyNonEmptyCollections() {
+        elementTrials.nonEmptyCollections(() -> new Builder<Integer, List<Integer>>() {
+            private final List<Integer> underlyingBuilder = new ArrayList<>();
+            @Override
+            public void add(Integer caze) {
+                underlyingBuilder.add(caze);
+            }
+            @Override
+            public List<Integer> build() {
+                return underlyingBuilder;
+            }
+        }).withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(empty())));
+        });
+    }
+
+    @Test
+    void nonEmptyImmutableListsShouldYieldOnlyNonEmptyLists() {
+        elementTrials.nonEmptyImmutableLists().withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(empty())));
+        });
+    }
+
+    @Test
+    void nonEmptyImmutableSetsShouldYieldOnlyNonEmptySets() {
+        elementTrials.nonEmptyImmutableSets().withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(empty())));
+        });
+    }
+
+    @Test
+    void nonEmptyImmutableSortedSetsShouldYieldOnlyNonEmptySortedSets() {
+        elementTrials.nonEmptyImmutableSortedSets(Comparator.naturalOrder()).withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(empty())));
+        });
+    }
+
+    @Test
+    void nonEmptyImmutableMapsShouldYieldOnlyNonEmptyMaps() {
+        elementTrials.nonEmptyImmutableMaps(api.booleans()).withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(anEmptyMap())));
+        });
+    }
+
+    @Test
+    void nonEmptyImmutableSortedMapsShouldYieldOnlyNonEmptySortedMaps() {
+        elementTrials.nonEmptyImmutableSortedMaps(Comparator.naturalOrder(), api.booleans()).withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(anEmptyMap())));
+        });
+    }
+
+    @Test
+    void nonEmptyStringsShouldYieldOnlyNonEmptyStrings() {
+        api.nonEmptyStrings().withLimit(50).supplyTo(collection -> {
+            assertThat(collection, is(not(emptyString())));
+        });
+    }
+}

--- a/core-library/src/test/scala/com/sageserpent/americium/NonEmptyCollectionsTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/NonEmptyCollectionsTest.scala
@@ -1,0 +1,52 @@
+package com.sageserpent.americium
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NonEmptyCollectionsTest extends AnyFlatSpec with Matchers {
+  val api = Trials.api
+
+  val elementTrials = api.integers
+
+  "nonEmptyCollections" should "yield only non-empty collections" in {
+    elementTrials.nonEmptyCollections[List[Int]].withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+
+  "nonEmptyLists" should "yield only non-empty lists" in {
+    elementTrials.nonEmptyLists.withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+
+  "nonEmptySets" should "yield only non-empty sets" in {
+    elementTrials.nonEmptySets.withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+
+  "nonEmptySortedSets" should "yield only non-empty sorted sets" in {
+    elementTrials.nonEmptySortedSets.withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+
+  "nonEmptyMaps" should "yield only non-empty maps" in {
+    elementTrials.nonEmptyMaps(api.booleans).withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+
+  "nonEmptySortedMaps" should "yield only non-empty sorted maps" in {
+    elementTrials.nonEmptySortedMaps(api.booleans).withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+
+  "nonEmptyStrings" should "yield only non-empty strings" in {
+    api.nonEmptyStrings.withLimit(50).supplyTo { collection =>
+      collection should not be empty
+    }
+  }
+}


### PR DESCRIPTION
This PR adds "non-empty" versions of the existing collection-generating methods to both the Scala and Java `Trials` APIs. This avoids the need for client-side filtration which can lead to starvation in complex trials.

The implementation leverages Americium's "gradual growth" strategy by ensuring at least one element is yielded before potentially adding more via existing collection logic.

Key changes:
- Scala API: `several` renamed to `collections` (alias maintained). Added `nonEmptyCollections`, `nonEmptyLists`, `nonEmptySets`, `nonEmptySortedSets`, `nonEmptyMaps`, `nonEmptySortedMaps`.
- Java API: Added `nonEmptyCollections`, `nonEmptyImmutableLists`, `nonEmptyImmutableSets`, `nonEmptyImmutableSortedSets`, `nonEmptyImmutableMaps`, `nonEmptyImmutableSortedMaps`.
- Both APIs: Added `nonEmptyStrings` to `TrialsApi` and `CharacterTrials`.
- Tests: New test classes `NonEmptyCollectionsTest` (Scala) and `NonEmptyCollectionsJavaTest` (Java) verify the non-empty property across all new methods.

---
*PR created automatically by Jules for task [4271428706245505584](https://jules.google.com/task/4271428706245505584) started by @sageserpent-open*