### PR TITLE
Add `chooseSeveralOf` to `TrialsApi`

### DIFF
--- a/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
+++ b/core-library/src/main/java/com/sageserpent/americium/java/TrialsApi.java
@@ -352,6 +352,19 @@ public interface TrialsApi {
                                             int combinationSize);
 
     /**
+     * Produce a trials instance that yields permutations of {@code candidates}
+     * of the given size.
+     *
+     * @param candidates     The items to be chosen from.
+     * @param numberToChoose The number of items to choose.
+     * @param <Element>      The type of the elements in {@code candidates}.
+     * @return A {@link Trials} instance that yields permutations of size
+     * {@code numberToChoose}.
+     */
+    <Element> Trials<List<Element>> chooseSeveralOf(Iterable<Element> candidates,
+                                                    int numberToChoose);
+
+    /**
      * Produce a trials instance whose cases are lists containing elements
      * picked alternately from {@code iterables}. The order of elements
      * contributed by any given iterable is preserved in the yielded lists,

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApi.scala
@@ -354,6 +354,24 @@ trait TrialsApi {
       combinationSize: Int
   ): Trials[Vector[Int]]
 
+  /** Produce a trials instance that yields permutations of {@code candidates}
+    * of the given size.
+    *
+    * @param candidates
+    *   The items to be chosen from.
+    * @param numberToChoose
+    *   The number of items to choose.
+    * @tparam Element
+    *   The type of the elements in {@code candidates}.
+    * @return
+    *   A [[Trials]] instance that yields permutations of size
+    *   {@code numberToChoose}.
+    */
+  def chooseSeveralOf[Element](
+      candidates: Iterable[Element],
+      numberToChoose: Int
+  ): Trials[Seq[Element]]
+
   /** Produce a trials instance whose cases are vectors containing elements
     * picked alternately from {@code iterables} . The order of elements
     * contributed by any given iterable is preserved in the yielded vectors, but

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsApiImplementation.scala
@@ -405,6 +405,17 @@ class TrialsApiImplementation extends CommonApi with ScalaTrialsApi {
       Choice(SortedMap.from(LazyList.from(1).zip(choices)))
     )
 
+  override def chooseSeveralOf[Element](
+      candidates: Iterable[Element],
+      numberToChoose: Int
+  ): Trials[Seq[Element]] = {
+    val indexedCandidates = candidates.toIndexedSeq
+    indexPermutations(
+      numberOfIndices = indexedCandidates.size,
+      permutationSize = numberToChoose
+    ).map(_.map(indexedCandidates.apply))
+  }
+
   override def indexCombinations(
       numberOfIndices: Int,
       combinationSize: Int

--- a/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialsImplementation.scala
@@ -503,7 +503,10 @@ case class TrialsImplementation[Case](
   )
 
   override def collections[Collection](
-      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
+      builderFactory: _root_.java.util.function.Supplier[Builder[
+        Case,
+        Collection
+      ]]
   ): TrialsImplementation[Collection] =
     severalImplementation(builderFactory.get())
 
@@ -517,16 +520,17 @@ case class TrialsImplementation[Case](
           partialResult.foreach(builder.add)
           builder.build()
         },
-        flatMap((item: Case) =>
-          addItems(item :: partialResult)
-        )
+        flatMap((item: Case) => addItems(item :: partialResult))
       )
 
     addItems(Nil)
   }
 
   override def nonEmptyCollections[Collection](
-      builderFactory: _root_.java.util.function.Supplier[Builder[Case, Collection]]
+      builderFactory: _root_.java.util.function.Supplier[Builder[
+        Case,
+        Collection
+      ]]
   ): TrialsImplementation[Collection] =
     nonEmptySeveralImplementation(builderFactory.get())
 

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsApiImplementation.scala
@@ -376,6 +376,14 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
     .map(_.map(Int.box).asJava)
     .javaTrials
 
+  override def chooseSeveralOf[Element](
+      candidates: JavaIterable[Element],
+      numberToChoose: Int
+  ): JavaTrials[JavaList[Element]] = scalaApi
+    .chooseSeveralOf(candidates.asScala, numberToChoose)
+    .map(_.asJava)
+    .javaTrials
+
   override def pickAlternatelyFrom[Element](
       shrinkToRoundRobin: Boolean,
       iterable: JavaIterable[Element]*
@@ -423,5 +431,8 @@ trait TrialsApiImplementation extends CommonApi with TrialsApiWart {
   override def shuffles[Element](
       items: JavaList[Element]
   ): JavaTrials[JavaList[Element]] =
-    scalaApi.shuffles[Element, List](items.asScala.toList).map(_.asJava).javaTrials
+    scalaApi
+      .shuffles[Element, List](items.asScala.toList)
+      .map(_.asJava)
+      .javaTrials
 }

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsSkeletalImplementation.scala
@@ -94,8 +94,7 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
   ): TrialsImplementation[Collection] =
     nonEmptySeveralImplementation(builderFactory.get())
 
-  override def immutableLists()
-      : TrialsImplementation[ImmutableList[Case]] =
+  override def immutableLists(): TrialsImplementation[ImmutableList[Case]] =
     severalImplementation(new Builder[Case, ImmutableList[Case]] {
       private val underlyingBuilder = ImmutableList.builder[Case]()
 
@@ -120,8 +119,7 @@ trait TrialsSkeletalImplementation[Case] extends JavaTrials[Case] {
         underlyingBuilder.build()
     })
 
-  override def immutableSets()
-      : TrialsImplementation[ImmutableSet[Case]] =
+  override def immutableSets(): TrialsImplementation[ImmutableSet[Case]] =
     severalImplementation(new Builder[Case, ImmutableSet[Case]] {
       private val underlyingBuilder = ImmutableSet.builder[Case]()
 

--- a/core-library/src/test/java/com/sageserpent/americium/java/TrialsApiTests.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/TrialsApiTests.java
@@ -889,6 +889,32 @@ public class TrialsApiTests {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 7})
+    void chooseSeveralOfCasesShouldCoverAllPossibilities(int numberOfCandidates) {
+        final List<Integer> candidates = IntStream.range(0, numberOfCandidates)
+                                                  .boxed()
+                                                  .collect(Collectors.toList());
+
+        for (int numberToChoose = 0; numberOfCandidates >= numberToChoose;
+             ++numberToChoose) {
+            final int numberOfPermutations =
+                    BargainBasement.numberOfPermutations(numberOfCandidates,
+                                                         numberToChoose);
+
+            final Set<List<Integer>> chosenPermutations = new HashSet<>();
+
+            api
+                    .chooseSeveralOf(candidates, numberToChoose)
+                    .withStrategy(unused -> CasesLimitStrategy.counted(
+                            numberOfPermutations,
+                            numberOfPermutations))
+                    .supplyTo(chosenPermutations::add);
+
+            assertThat(chosenPermutations.size(), is(numberOfPermutations));
+        }
+    }
+
     @Test
     void alternatePickingShouldForwardCorrectly() {
         final Consumer<List<Integer>> consumer = mock(Consumer.class);

--- a/core-library/src/test/java/com/sageserpent/americium/java/TrialsApiTests.java
+++ b/core-library/src/test/java/com/sageserpent/americium/java/TrialsApiTests.java
@@ -902,7 +902,7 @@ public class TrialsApiTests {
                     BargainBasement.numberOfPermutations(numberOfCandidates,
                                                          numberToChoose);
 
-            final Set<List<Integer>> chosenPermutations = new HashSet<>();
+            final List<List<Integer>> chosenPermutations = new ArrayList<>();
 
             api
                     .chooseSeveralOf(candidates, numberToChoose)
@@ -912,6 +912,8 @@ public class TrialsApiTests {
                     .supplyTo(chosenPermutations::add);
 
             assertThat(chosenPermutations.size(), is(numberOfPermutations));
+            assertThat(new HashSet<>(chosenPermutations).size(),
+                       is(numberOfPermutations));
         }
     }
 

--- a/core-library/src/test/scala/com/sageserpent/americium/ChooseSeveralOfTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/ChooseSeveralOfTest.scala
@@ -1,0 +1,71 @@
+package com.sageserpent.americium
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ChooseSeveralOfTest extends AnyFlatSpec with Matchers {
+  val api = Trials.api
+
+  private val itemsAndSizeToChooseTrials: Trials[(Vector[Int], Int)] =
+    for {
+      items        <- api.integers.several[Vector[Int]]
+      sizeToChoose <- api.integers(0, items.size)
+    } yield items -> sizeToChoose
+
+  "chooseSeveralOf" should "yield a permutation of some of the original items" in {
+    itemsAndSizeToChooseTrials.withLimit(50).supplyTo {
+      case (items, sizeToChoose) =>
+        api.chooseSeveralOf(items, sizeToChoose).withLimit(10).supplyTo {
+          chosen =>
+            chosen.size should be(sizeToChoose)
+            chosen.toSet.subsetOf(items.toSet) should be(true)
+            // Since we are picking a permutation, it should have distinct
+            // elements if the input has distinct elements.
+            // Wait, if the input has duplicates, the output can have
+            // duplicates.
+            // But it's a sample without replacement from the indices.
+            if (items.distinct.size == items.size) {
+              chosen.distinct.size should be(sizeToChoose)
+            }
+        }
+    }
+  }
+
+  it should "eventually yield all possible permutations of the given size" in {
+    val items                        = Vector(1, 2, 3)
+    val sizeToChoose                 = 2
+    val expectedNumberOfPermutations = 6 // 3 * 2
+    val permutations                 =
+      api
+        .chooseSeveralOf(items, sizeToChoose)
+        .withLimit(100)
+        .asIterator()
+        .to(LazyList)
+        .toSet
+    permutations should have size expectedNumberOfPermutations
+  }
+
+  it should "handle choosing zero items" in {
+    val items = Vector(1, 2, 3)
+    api.chooseSeveralOf(items, 0).withLimit(1).supplyTo { chosen =>
+      chosen shouldBe empty
+    }
+  }
+
+  it should "handle choosing all items (behaving like a shuffle)" in {
+    val items = Vector(1, 2, 3)
+    api
+      .chooseSeveralOf(items, items.size)
+      .withLimit(100)
+      .asIterator()
+      .to(LazyList)
+      .toSet should have size 6
+  }
+
+  it should "throw an requirement error if numberToChoose is greater than the number of candidates" in {
+    val items = Vector(1, 2, 3)
+    an[IllegalArgumentException] should be thrownBy {
+      api.chooseSeveralOf(items, 4)
+    }
+  }
+}

--- a/core-library/src/test/scala/com/sageserpent/americium/ChooseSeveralOfTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/ChooseSeveralOfTest.scala
@@ -35,14 +35,14 @@ class ChooseSeveralOfTest extends AnyFlatSpec with Matchers {
     val items                        = Vector(1, 2, 3)
     val sizeToChoose                 = 2
     val expectedNumberOfPermutations = 6 // 3 * 2
-    val permutations                 =
+    val permutations =
       api
         .chooseSeveralOf(items, sizeToChoose)
         .withLimit(100)
         .asIterator()
-        .to(LazyList)
-        .toSet
+        .to(List)
     permutations should have size expectedNumberOfPermutations
+    permutations.distinct should have size expectedNumberOfPermutations
   }
 
   it should "handle choosing zero items" in {
@@ -54,12 +54,14 @@ class ChooseSeveralOfTest extends AnyFlatSpec with Matchers {
 
   it should "handle choosing all items (behaving like a shuffle)" in {
     val items = Vector(1, 2, 3)
-    api
+    val permutations = api
       .chooseSeveralOf(items, items.size)
       .withLimit(100)
       .asIterator()
-      .to(LazyList)
-      .toSet should have size 6
+      .to(List)
+
+    permutations should have size 6
+    permutations.distinct should have size 6
   }
 
   it should "throw an requirement error if numberToChoose is greater than the number of candidates" in {

--- a/core-library/src/test/scala/com/sageserpent/americium/NonEmptyCollectionsTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/NonEmptyCollectionsTest.scala
@@ -9,8 +9,9 @@ class NonEmptyCollectionsTest extends AnyFlatSpec with Matchers {
   val elementTrials = api.integers
 
   "nonEmptyCollections" should "yield only non-empty collections" in {
-    elementTrials.nonEmptyCollections[List[Int]].withLimit(50).supplyTo { collection =>
-      collection should not be empty
+    elementTrials.nonEmptyCollections[List[Int]].withLimit(50).supplyTo {
+      collection =>
+        collection should not be empty
     }
   }
 
@@ -33,14 +34,16 @@ class NonEmptyCollectionsTest extends AnyFlatSpec with Matchers {
   }
 
   "nonEmptyMaps" should "yield only non-empty maps" in {
-    elementTrials.nonEmptyMaps(api.booleans).withLimit(50).supplyTo { collection =>
-      collection should not be empty
+    elementTrials.nonEmptyMaps(api.booleans).withLimit(50).supplyTo {
+      collection =>
+        collection should not be empty
     }
   }
 
   "nonEmptySortedMaps" should "yield only non-empty sorted maps" in {
-    elementTrials.nonEmptySortedMaps(api.booleans).withLimit(50).supplyTo { collection =>
-      collection should not be empty
+    elementTrials.nonEmptySortedMaps(api.booleans).withLimit(50).supplyTo {
+      collection =>
+        collection should not be empty
     }
   }
 

--- a/core-library/src/test/scala/com/sageserpent/americium/ShufflesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/ShufflesTest.scala
@@ -31,9 +31,9 @@ class ShufflesTest extends AnyFlatSpec with Matchers {
   }
 
   it should "eventually yield all possible shuffles" in {
-    val items = Vector(1, 2, 3)
+    val items                    = Vector(1, 2, 3)
     val expectedNumberOfShuffles = 6 // 3!
-    val shuffles =
+    val shuffles                 =
       api.shuffles(items).withLimit(100).asIterator().to(LazyList).toSet
     shuffles should have size expectedNumberOfShuffles
   }

--- a/core-library/src/test/scala/com/sageserpent/americium/SplitsIntoPiecesTest.scala
+++ b/core-library/src/test/scala/com/sageserpent/americium/SplitsIntoPiecesTest.scala
@@ -56,15 +56,14 @@ class SplitsIntoPiecesTest extends AnyFlatSpec with Matchers {
 
   "splitsIntoNonEmptyPieces" should "yield non-empty pieces that concatenate to the original items" in {
     val testCaseTrials = for {
-      items          <- itemsTrials
-      pieces         <- api.splitsIntoNonEmptyPieces(items)
+      items  <- itemsTrials
+      pieces <- api.splitsIntoNonEmptyPieces(items)
     } yield (items, pieces)
 
-    testCaseTrials.withLimit(100).supplyTo {
-      case (items, pieces) =>
-        pieces.size should be <= items.size
-        pieces.flatten should be(items)
-        pieces.forall(_.nonEmpty) should be(true)
+    testCaseTrials.withLimit(100).supplyTo { case (items, pieces) =>
+      pieces.size should be <= items.size
+      pieces.flatten should be(items)
+      pieces.forall(_.nonEmpty) should be(true)
     }
   }
 }


### PR DESCRIPTION
This PR adds the `chooseSeveralOf` method to the `TrialsApi` in both Scala and Java. The method provides a way to generate a random sample (permutation) of a given size from a collection of items. This is a common requirement in property-based testing, previously addressed by a less efficient implementation in `RandomEnrichment`.

Key changes:
- Added `chooseSeveralOf` to `com.sageserpent.americium.TrialsApi` (Scala).
- Implemented `chooseSeveralOf` in `com.sageserpent.americium.TrialsApiImplementation` using `indexPermutations`.
- Added `chooseSeveralOf` to `com.sageserpent.americium.java.TrialsApi` (Java).
- Implemented the Java bridge in `com.sageserpent.americium.java.TrialsApiImplementation`.
- Added comprehensive unit tests in `ChooseSeveralOfTest.scala` and `TrialsApiTests.java`.
- Applied `scalafmt` to all modified Scala files.

---
*PR created automatically by Jules for task [13422005183911223337](https://jules.google.com/task/13422005183911223337) started by @sageserpent-open*