### PR TITLE
Fix SBT 2.0 build error in testGrouping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val commonSettings = Seq(
   Test / test / logLevel    := Level.Error,
   Test / testOptions += Tests.Argument(jupiterTestFramework, "-q"),
   // Test grouping for isolated databases
-  Test / testGrouping := {
+  Test / testGrouping := Def.uncached {
     val tests = (Test / definedTests).value
 
     tests


### PR DESCRIPTION
In SBT 2.0, all task results must be serializable for the new automatic caching mechanism. 
Since 'Test / testGrouping' returns 'sbt.Tests.Group' which contains non-serializable components 
(like 'SubProcess' and 'OutputStream'), it caused a build failure at startup. 
This change marks the task as uncached using 'Def.uncached' to bypass the serialization requirement.

---
*PR created automatically by Jules for task [531087158551432237](https://jules.google.com/task/531087158551432237) started by @sageserpent-open*