### PR TITLE
Enrich JUnit5 integration with TrialException failure diagnostics and replay support

### DIFF
--- a/core-library/src/main/scala/com/sageserpent/americium/TrialException.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/TrialException.scala
@@ -1,0 +1,22 @@
+package com.sageserpent.americium
+
+abstract class TrialException(cause: Throwable)
+    extends RuntimeException(cause) {
+  override def toString: String =
+    s"Trial exception with underlying cause:\n$getCause\nProvoked by test case:\n$provokingCase\n\nReproduce via Java property:\ntrials.recipeHash=$recipeHash\n\n... or via Java property:\ntrials.recipe=\"$escapedRecipe\"\n\n... or via `withRecipe` using recipe:\n$recipe"
+
+  /** @return
+    *   The {@code Case} that provoked the exception.
+    */
+  def provokingCase: Any
+
+  /** @return
+    *   A recipe that can be used to reproduce the provoking {@code Case} when
+    *   supplied to the corresponding trials instance.
+    */
+  def recipe: String
+
+  def escapedRecipe: String
+
+  def recipeHash: String
+}

--- a/core-library/src/main/scala/com/sageserpent/americium/java/TrialsFactoring.scala
+++ b/core-library/src/main/scala/com/sageserpent/americium/java/TrialsFactoring.scala
@@ -18,23 +18,10 @@ trait TrialsFactoring[+Case] {
   def reproduce(recipe: String): Case
 
   abstract class TrialException(cause: Throwable)
-      extends RuntimeException(cause) {
-    override def toString: String =
-      s"Trial exception with underlying cause:\n$getCause\nProvoked by test case:\n$provokingCase\n\nReproduce via Java property:\ntrials.recipeHash=$recipeHash\n\n... or via Java property:\ntrials.recipe=\"$escapedRecipe\"\n\n... or via `withRecipe` using recipe:\n$recipe"
-
+      extends com.sageserpent.americium.TrialException(cause) {
     /** @return
       *   The {@code Case} that provoked the exception.
       */
-    def provokingCase: Case
-
-    /** @return
-      *   A recipe that can be used to reproduce the provoking {@code Case} when
-      *   supplied to the corresponding trials instance.
-      */
-    def recipe: String
-
-    def escapedRecipe: String
-
-    def recipeHash: String
+    override def provokingCase: Case
   }
 }

--- a/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/TrialException.scala
+++ b/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/TrialException.scala
@@ -1,0 +1,14 @@
+package com.sageserpent.americium.junit5
+
+import com.sageserpent.americium.generation.Decision
+import org.apache.commons.text.StringEscapeUtils
+
+class TrialException(
+    cause: Throwable,
+    override val provokingCase: Any,
+    override val recipe: String,
+    override val recipeHash: String
+) extends com.sageserpent.americium.TrialException(cause) {
+  override val escapedRecipe: String =
+    StringEscapeUtils.escapeJava(Decision.parseRecipe(recipe).shorthandRecipe)
+}

--- a/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/java/TrialsTestExtension.scala
+++ b/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/java/TrialsTestExtension.scala
@@ -316,13 +316,13 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
 
     val supply = supplyToSyntax(context)
 
-    val casesAvailableForReplayByUniqueId: mutable.Map[UniqueId, AnyRef] =
+    val casesAvailableForReplayByUniqueId: mutable.Map[UniqueId, (AnyRef, String)] =
       mutable.Map.from(
         replayedUniqueIds
           .flatMap(uniqueId =>
             JUnit5ReplayStorage.jUnit5ReplayStorage
               .recipeFromUniqueId(uniqueId.toString)
-              .map(uniqueId -> supply.reproduce(_).asInstanceOf[AnyRef])
+              .map(recipe => uniqueId -> (supply.reproduce(recipe).asInstanceOf[AnyRef], recipe))
           )
       )
 
@@ -372,6 +372,11 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
               throwable => throw throwable
             }
 
+            private def activeReplayCaseAndRecipe: Option[(AnyRef, String)] = {
+              val uniqueId = TestExecutionListenerCapturingUniqueIds.uniqueId().toScala
+              uniqueId.flatMap(casesAvailableForReplayByUniqueId.get)
+            }
+
             override protected def parameters: Array[AnyRef] = {
               val potentialReplayedTestCase =
                 TestExecutionListenerCapturingUniqueIds
@@ -380,7 +385,7 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
                   .flatMap(casesAvailableForReplayByUniqueId.get)
 
               potentialReplayedTestCase.fold(ifEmpty = Array.empty[AnyRef]) {
-                testCase =>
+                case (testCase, _) =>
                   extractedParameters(wrap(testCase))
               }
             }
@@ -391,7 +396,9 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
               val details =
                 if (1 == casesAvailableForReplayByUniqueId.size)
                   casesAvailableForReplayByUniqueId
-                    .getOrElse(casesAvailableForReplayByUniqueId.keys.head, "")
+                    .get(casesAvailableForReplayByUniqueId.keys.head)
+                    .map(_._1)
+                    .getOrElse("")
                 else ""
 
               s"${super.getDisplayName(invocationIndex)} $details"
@@ -407,20 +414,57 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
                     invocationContext: ReflectiveInvocationContext[Method],
                     extensionContext: ExtensionContext
                 ): Unit = {
-                  TestExecutionListenerCapturingUniqueIds
-                    .uniqueId()
-                    .ifPresent(casesAvailableForReplayByUniqueId.remove)
+                  val active = activeReplayCaseAndRecipe
 
-                  delegatedSuper.interceptTestTemplateMethod(
-                    invocation,
-                    invocationContext,
-                    extensionContext
-                  )
+                  try {
+                    TestExecutionListenerCapturingUniqueIds
+                      .uniqueId()
+                      .ifPresent(casesAvailableForReplayByUniqueId.remove)
+
+                    delegatedSuper.interceptTestTemplateMethod(
+                      invocation,
+                      invocationContext,
+                      extensionContext
+                    )
+                  } catch {
+                    case throwable: Throwable if !additionalExceptionsToHandleAsFiltration.exists(_.isInstance(throwable)) =>
+                      active.foreach { case (caze, recipe) =>
+                        val recipeHash = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
+
+                        extensionContext.publishReportEntry(
+                          Map(
+                            "recipe" -> recipe,
+                            "recipeHash" -> recipeHash
+                          ).asJava
+                        )
+
+                        caseFailureReporting.report(throwable)
+
+                        throw new com.sageserpent.americium.junit5.TrialException(
+                          cause = throwable,
+                          provokingCase = caze,
+                          recipe = recipe,
+                          recipeHash = recipeHash
+                        )
+                      }
+                      throw throwable
+                  }
                 }
               }
             }
             override protected def testWatcher: TestWatcher =
-              new TestWatcher() {}
+              new TestWatcher() {
+                override def testFailed(
+                    context: ExtensionContext,
+                    cause: Throwable
+                ): Unit = {
+                  cause match {
+                    case _: com.sageserpent.americium.junit5.TrialException => // already reported
+                    case _ =>
+                      caseFailureReporting.report(cause)
+                  }
+                }
+              }
           }
       })
     } else
@@ -442,6 +486,10 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
               testIntegrationContext.caseFailureReporting
             override protected val parameters: Array[AnyRef] =
               extractedParameters(wrappedTestCase)
+
+            val recipe: String = testIntegrationContext.recipe
+            val recipeHash: String = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
+            val caze: AnyRef = testIntegrationContext.caze
 
             override def getDisplayName(invocationIndex: Int): String = {
               val shrinkagePrefix =
@@ -471,14 +519,33 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
                   // courtesy of JUnit5, so let's use it as intended.
                   JUnit5ReplayStorage.jUnit5ReplayStorage.recordUniqueId(
                     extensionContext.getUniqueId,
-                    testIntegrationContext.recipe
+                    recipe
                   )
 
-                  delegatedSuper.interceptTestTemplateMethod(
-                    invocation,
-                    invocationContext,
-                    extensionContext
-                  )
+                  try {
+                    delegatedSuper.interceptTestTemplateMethod(
+                      invocation,
+                      invocationContext,
+                      extensionContext
+                    )
+                  } catch {
+                    case throwable: Throwable if !additionalExceptionsToHandleAsFiltration.exists(_.isInstance(throwable)) =>
+                      extensionContext.publishReportEntry(
+                        Map(
+                          "recipe" -> recipe,
+                          "recipeHash" -> recipeHash
+                        ).asJava
+                      )
+
+                      caseFailureReporting.report(throwable)
+
+                      throw new com.sageserpent.americium.junit5.TrialException(
+                        cause = throwable,
+                        provokingCase = caze,
+                        recipe = recipe,
+                        recipeHash = recipeHash
+                      )
+                  }
                 }
               }
             }
@@ -489,7 +556,11 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
                     context: ExtensionContext,
                     cause: Throwable
                 ): Unit = {
-                  caseFailureReporting.report(cause)
+                  cause match {
+                    case _: com.sageserpent.americium.junit5.TrialException => // already reported
+                    case _ =>
+                      caseFailureReporting.report(cause)
+                  }
                 }
               }
           }

--- a/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/java/TrialsTestExtension.scala
+++ b/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/java/TrialsTestExtension.scala
@@ -336,6 +336,45 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
 
         override def next(): TestTemplateInvocationContext =
           new TrialTemplateInvocationContext {
+            private def activeReplayCaseAndRecipe: Option[(AnyRef, String)] = {
+              val uniqueId = TestExecutionListenerCapturingUniqueIds.uniqueId().toScala
+              uniqueId.flatMap(casesAvailableForReplayByUniqueId.get)
+            }
+
+            override def getAdditionalExtensions: JavaList[Extension] = {
+              val extensions = new java.util.ArrayList[Extension](super.getAdditionalExtensions)
+              extensions.add(new TestExecutionExceptionHandler {
+                override def handleTestExecutionException(
+                    context: ExtensionContext,
+                    throwable: Throwable
+                ): Unit = {
+                  if (!additionalExceptionsToHandleAsFiltration.exists(_.isInstance(throwable))) {
+                    activeReplayCaseAndRecipe.foreach { case (caze, recipe) =>
+                      val recipeHash = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
+
+                      context.publishReportEntry(
+                        Map(
+                          "recipe" -> recipe,
+                          "recipeHash" -> recipeHash
+                        ).asJava
+                      )
+
+                      caseFailureReporting.report(throwable)
+
+                      throw new com.sageserpent.americium.junit5.TrialException(
+                        cause = throwable,
+                        provokingCase = caze,
+                        recipe = recipe,
+                        recipeHash = recipeHash
+                      )
+                    }
+                  }
+                  throw throwable
+                }
+              })
+              extensions
+            }
+
             override protected def inlinedCaseFiltration
                 : InlinedCaseFiltration =
               (
@@ -372,11 +411,6 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
               throwable => throw throwable
             }
 
-            private def activeReplayCaseAndRecipe: Option[(AnyRef, String)] = {
-              val uniqueId = TestExecutionListenerCapturingUniqueIds.uniqueId().toScala
-              uniqueId.flatMap(casesAvailableForReplayByUniqueId.get)
-            }
-
             override protected def parameters: Array[AnyRef] = {
               val potentialReplayedTestCase =
                 TestExecutionListenerCapturingUniqueIds
@@ -393,13 +427,10 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
             override def getDisplayName(
                 invocationIndex: Int
             ): String = {
-              val details =
-                if (1 == casesAvailableForReplayByUniqueId.size)
-                  casesAvailableForReplayByUniqueId
-                    .get(casesAvailableForReplayByUniqueId.keys.head)
-                    .map(_._1)
-                    .getOrElse("")
-                else ""
+              val details = Option(casesAvailableForReplayByUniqueId)
+                .filter(_.size == 1)
+                .flatMap(_.values.headOption)
+                .fold(ifEmpty = "") { case (testCase, _) => testCase.toString }
 
               s"${super.getDisplayName(invocationIndex)} $details"
             }
@@ -414,41 +445,15 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
                     invocationContext: ReflectiveInvocationContext[Method],
                     extensionContext: ExtensionContext
                 ): Unit = {
-                  val active = activeReplayCaseAndRecipe
+                  TestExecutionListenerCapturingUniqueIds
+                    .uniqueId()
+                    .ifPresent(casesAvailableForReplayByUniqueId.remove)
 
-                  try {
-                    TestExecutionListenerCapturingUniqueIds
-                      .uniqueId()
-                      .ifPresent(casesAvailableForReplayByUniqueId.remove)
-
-                    delegatedSuper.interceptTestTemplateMethod(
-                      invocation,
-                      invocationContext,
-                      extensionContext
-                    )
-                  } catch {
-                    case throwable: Throwable if !additionalExceptionsToHandleAsFiltration.exists(_.isInstance(throwable)) =>
-                      active.foreach { case (caze, recipe) =>
-                        val recipeHash = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
-
-                        extensionContext.publishReportEntry(
-                          Map(
-                            "recipe" -> recipe,
-                            "recipeHash" -> recipeHash
-                          ).asJava
-                        )
-
-                        caseFailureReporting.report(throwable)
-
-                        throw new com.sageserpent.americium.junit5.TrialException(
-                          cause = throwable,
-                          provokingCase = caze,
-                          recipe = recipe,
-                          recipeHash = recipeHash
-                        )
-                      }
-                      throw throwable
-                  }
+                  delegatedSuper.interceptTestTemplateMethod(
+                    invocation,
+                    invocationContext,
+                    extensionContext
+                  )
                 }
               }
             }
@@ -479,6 +484,40 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
             private val wrappedTestCase: Vector[AnyRef] =
               wrap(testIntegrationContext.caze)
 
+            val recipe: String = testIntegrationContext.recipe
+            val recipeHash: String = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
+            val caze: AnyRef = testIntegrationContext.caze
+
+            override def getAdditionalExtensions: JavaList[Extension] = {
+              val extensions = new java.util.ArrayList[Extension](super.getAdditionalExtensions)
+              extensions.add(new TestExecutionExceptionHandler {
+                override def handleTestExecutionException(
+                    context: ExtensionContext,
+                    throwable: Throwable
+                ): Unit = {
+                  if (!additionalExceptionsToHandleAsFiltration.exists(_.isInstance(throwable))) {
+                    context.publishReportEntry(
+                      Map(
+                        "recipe" -> recipe,
+                        "recipeHash" -> recipeHash
+                      ).asJava
+                    )
+
+                    caseFailureReporting.report(throwable)
+
+                    throw new com.sageserpent.americium.junit5.TrialException(
+                      cause = throwable,
+                      provokingCase = caze,
+                      recipe = recipe,
+                      recipeHash = recipeHash
+                    )
+                  }
+                  throw throwable
+                }
+              })
+              extensions
+            }
+
             override protected def inlinedCaseFiltration
                 : InlinedCaseFiltration =
               testIntegrationContext.inlinedCaseFiltration
@@ -486,10 +525,6 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
               testIntegrationContext.caseFailureReporting
             override protected val parameters: Array[AnyRef] =
               extractedParameters(wrappedTestCase)
-
-            val recipe: String = testIntegrationContext.recipe
-            val recipeHash: String = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
-            val caze: AnyRef = testIntegrationContext.caze
 
             override def getDisplayName(invocationIndex: Int): String = {
               val shrinkagePrefix =
@@ -522,30 +557,11 @@ class TrialsTestExtension extends TestTemplateInvocationContextProvider {
                     recipe
                   )
 
-                  try {
-                    delegatedSuper.interceptTestTemplateMethod(
-                      invocation,
-                      invocationContext,
-                      extensionContext
-                    )
-                  } catch {
-                    case throwable: Throwable if !additionalExceptionsToHandleAsFiltration.exists(_.isInstance(throwable)) =>
-                      extensionContext.publishReportEntry(
-                        Map(
-                          "recipe" -> recipe,
-                          "recipeHash" -> recipeHash
-                        ).asJava
-                      )
-
-                      caseFailureReporting.report(throwable)
-
-                      throw new com.sageserpent.americium.junit5.TrialException(
-                        cause = throwable,
-                        provokingCase = caze,
-                        recipe = recipe,
-                        recipeHash = recipeHash
-                      )
-                  }
+                  delegatedSuper.interceptTestTemplateMethod(
+                    invocation,
+                    invocationContext,
+                    extensionContext
+                  )
                 }
               }
             }

--- a/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/package.scala
+++ b/junit5-integration/src/main/scala/com/sageserpent/americium/junit5/package.scala
@@ -134,13 +134,13 @@ package object junit5 {
         .replayedUniqueIds()
         .asScala
 
-    val casesAvailableForReplayByUniqueId: mutable.Map[UniqueId, Case] =
+    val casesAvailableForReplayByUniqueId: mutable.Map[UniqueId, (Case, String)] =
       mutable.Map.from(
         replayedUniqueIds
           .flatMap(uniqueId =>
             JUnit5ReplayStorage.jUnit5ReplayStorage
               .recipeFromUniqueId(uniqueId.toString)
-              .map(uniqueId -> reproduceFromRecipe(_))
+              .map(recipe => uniqueId -> (reproduceFromRecipe(recipe), recipe))
           )
       )
 
@@ -190,6 +190,7 @@ package object junit5 {
             if (1 == casesAvailableForReplayByUniqueId.size)
               casesAvailableForReplayByUniqueId
                 .get(casesAvailableForReplayByUniqueId.keys.head)
+                .map(_._1)
                 .getOrElse("")
             else ""
 
@@ -199,19 +200,22 @@ package object junit5 {
               val uniqueId =
                 TestExecutionListenerCapturingUniqueIds.uniqueId.toScala
 
-              val potentialReplayedTestCase =
+              val potentialReplayedTestCaseAndRecipe =
                 uniqueId.flatMap(casesAvailableForReplayByUniqueId.get)
 
               uniqueId.foreach(casesAvailableForReplayByUniqueId.remove)
 
-              potentialReplayedTestCase.foreach(
+              potentialReplayedTestCaseAndRecipe.foreach { case (caze, recipe) =>
+                val recipeHash = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
                 invoke(
                   parameterisedTest,
-                  _,
+                  caze,
                   inlinedCaseFiltration,
-                  caseFailureReporting
+                  caseFailureReporting,
+                  recipe,
+                  recipeHash
                 )
-              )
+              }
             }
           )
         }
@@ -226,6 +230,7 @@ package object junit5 {
         val inlinedCaseFiltration = context.inlinedCaseFiltration
         val caseFailureReporting  = context.caseFailureReporting
         val recipe                = context.recipe
+        val recipeHash            = com.sageserpent.americium.generation.Decision.parseRecipe(recipe).recipeHash
 
         dynamicTest(
           s"[${1 + invocationIndex}] $shrinkagePrefix${pprint.PPrinter.BlackWhite(caze)}",
@@ -242,7 +247,9 @@ package object junit5 {
               parameterisedTest,
               caze,
               inlinedCaseFiltration,
-              caseFailureReporting
+              caseFailureReporting,
+              recipe,
+              recipeHash
             )
           }
         )
@@ -253,7 +260,9 @@ package object junit5 {
       parameterisedTest: Case => Unit,
       caze: Case,
       inlinedCaseFiltration: InlinedCaseFiltration,
-      caseFailureReporting: CaseFailureReporting
+      caseFailureReporting: CaseFailureReporting,
+      recipe: String,
+      recipeHash: String
   ): Unit = {
     val eligible: Boolean =
       try {
@@ -265,7 +274,12 @@ package object junit5 {
       } catch {
         case throwable: Throwable =>
           caseFailureReporting.report(throwable)
-          throw throwable
+          throw new TrialException(
+            cause = throwable,
+            provokingCase = caze,
+            recipe = recipe,
+            recipeHash = recipeHash
+          )
       }
 
     if (!eligible) throw new TestAbortedException

--- a/junit5-integration/src/test/java/com/sageserpent/americium/junit5/java/FailingTrialsTestExample.java
+++ b/junit5-integration/src/test/java/com/sageserpent/americium/junit5/java/FailingTrialsTestExample.java
@@ -9,13 +9,15 @@ import org.junit.jupiter.api.Tag;
 public class FailingTrialsTestExample {
     private final static TrialsApi api = Trials.api();
 
-    public static final Trials<Integer> integers = api.integers(1, 10);
+    public static final Trials<Integer> integers = api.choose(1, 2, 3, 4, 5);
+
+    public static int failingCase = 1;
 
     @Tag("failingTest")
     @TrialsTest(trials = "integers", casesLimit = 5)
     void failingTest(int caze) {
-        if (caze == 1) {
-            throw new RuntimeException("Deliberate failure for caze 1");
+        if (caze == failingCase) {
+            throw new RuntimeException("Deliberate failure for caze " + caze);
         }
     }
 }

--- a/junit5-integration/src/test/java/com/sageserpent/americium/junit5/java/FailingTrialsTestExample.java
+++ b/junit5-integration/src/test/java/com/sageserpent/americium/junit5/java/FailingTrialsTestExample.java
@@ -1,0 +1,21 @@
+package com.sageserpent.americium.junit5.java;
+
+import com.sageserpent.americium.java.Trials;
+import com.sageserpent.americium.java.TrialsApi;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+
+@Disabled
+public class FailingTrialsTestExample {
+    private final static TrialsApi api = Trials.api();
+
+    public static final Trials<Integer> integers = api.integers(1, 10);
+
+    @Tag("failingTest")
+    @TrialsTest(trials = "integers", casesLimit = 5)
+    void failingTest(int caze) {
+        if (caze == 1) {
+            throw new RuntimeException("Deliberate failure for caze 1");
+        }
+    }
+}

--- a/junit5-integration/src/test/scala/com/sageserpent/americium/junit5/JUnit5FailureAndReplaySpec.scala
+++ b/junit5-integration/src/test/scala/com/sageserpent/americium/junit5/JUnit5FailureAndReplaySpec.scala
@@ -10,6 +10,9 @@ import org.scalatest.matchers.should.Matchers
 
 class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
   "running a failing dynamicTest under JUnit5" should "produce com.sageserpent.americium.junit5.TrialException with recipe/recipeId diagnostics and support replay" in {
+    // Set a different failing case to prove we can vary which case fails dynamically!
+    FailingDynamicTestExample.failingCase = 3
+
     val results = EngineTestKit.engine("junit-jupiter")
       .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
       .configurationParameter(
@@ -71,6 +74,9 @@ class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
   }
 
   "running a failing annotated TrialsTest under JUnit5" should "produce com.sageserpent.americium.junit5.TrialException with recipe/recipeId diagnostics and support replay" in {
+    // Set a different failing case to prove we can vary which case fails dynamically!
+    FailingTrialsTestExample.failingCase = 4
+
     val results = EngineTestKit.engine("junit-jupiter")
       .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
       .configurationParameter(
@@ -136,10 +142,15 @@ class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
 class FailingDynamicTestExample {
   @TestFactory
   def failingTest(): DynamicTests = {
-    Trials.api.integers(1, 10).withLimit(5).dynamicTests { caze =>
-      if (caze == 1) {
-        throw new RuntimeException("Deliberate failure for caze 1")
+    // Choose 1, 2, 3, 4, 5 so we are guaranteed to include the failing case
+    Trials.api.choose(1, 2, 3, 4, 5).withLimit(5).dynamicTests { caze =>
+      if (caze == FailingDynamicTestExample.failingCase) {
+        throw new RuntimeException(s"Deliberate failure for caze $caze")
       }
     }
   }
+}
+
+object FailingDynamicTestExample {
+  var failingCase: Int = 1
 }

--- a/junit5-integration/src/test/scala/com/sageserpent/americium/junit5/JUnit5FailureAndReplaySpec.scala
+++ b/junit5-integration/src/test/scala/com/sageserpent/americium/junit5/JUnit5FailureAndReplaySpec.scala
@@ -1,0 +1,145 @@
+package com.sageserpent.americium.junit5
+
+import com.sageserpent.americium.Trials
+import com.sageserpent.americium.junit5.java.FailingTrialsTestExample
+import org.junit.jupiter.api.TestFactory
+import org.junit.platform.engine.discovery.DiscoverySelectors
+import org.junit.platform.testkit.engine.EngineTestKit
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
+  "running a failing dynamicTest under JUnit5" should "produce com.sageserpent.americium.junit5.TrialException with recipe/recipeId diagnostics and support replay" in {
+    val results = EngineTestKit.engine("junit-jupiter")
+      .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
+      .configurationParameter(
+        "junit.jupiter.conditions.deactivate",
+        "org.junit.*DisabledCondition"
+      )
+      .execute()
+
+    val testEvents = results.testEvents()
+    val failedTests = testEvents.failed().list()
+    failedTests should not be empty
+
+    val failure = failedTests.get(0).getRequiredPayload(classOf[org.junit.platform.engine.TestExecutionResult]).getThrowable.get()
+    failure shouldBe a[com.sageserpent.americium.junit5.TrialException]
+    val trialException = failure.asInstanceOf[com.sageserpent.americium.junit5.TrialException]
+    val recipe = trialException.recipe
+    val recipeHash = trialException.recipeHash
+
+    recipe should not be empty
+    recipeHash should not be empty
+    trialException.toString should include("Reproduce via Java property:")
+    trialException.toString should include("trials.recipeHash=")
+
+    // Now test replay with trials.recipe
+    System.setProperty("trials.recipe", recipe)
+    try {
+      val replayResults = EngineTestKit.engine("junit-jupiter")
+        .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
+        .configurationParameter(
+          "junit.jupiter.conditions.deactivate",
+          "org.junit.*DisabledCondition"
+        )
+        .execute()
+
+      val replayEvents = replayResults.testEvents()
+      replayEvents.started().count() shouldBe 1
+      replayEvents.failed().count() shouldBe 1
+    } finally {
+      System.clearProperty("trials.recipe")
+    }
+
+    // Now test replay with trials.recipeHash
+    System.setProperty("trials.recipeHash", recipeHash)
+    try {
+      val replayResults = EngineTestKit.engine("junit-jupiter")
+        .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
+        .configurationParameter(
+          "junit.jupiter.conditions.deactivate",
+          "org.junit.*DisabledCondition"
+        )
+        .execute()
+
+      val replayEvents = replayResults.testEvents()
+      replayEvents.started().count() shouldBe 1
+      replayEvents.failed().count() shouldBe 1
+    } finally {
+      System.clearProperty("trials.recipeHash")
+    }
+  }
+
+  "running a failing annotated TrialsTest under JUnit5" should "produce com.sageserpent.americium.junit5.TrialException with recipe/recipeId diagnostics and support replay" in {
+    val results = EngineTestKit.engine("junit-jupiter")
+      .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
+      .configurationParameter(
+        "junit.jupiter.conditions.deactivate",
+        "org.junit.*DisabledCondition"
+      )
+      .execute()
+
+    val testEvents = results.testEvents()
+    val failedTests = testEvents.failed().list()
+    failedTests should not be empty
+
+    val failure = failedTests.get(0).getRequiredPayload(classOf[org.junit.platform.engine.TestExecutionResult]).getThrowable.get()
+    failure shouldBe a[com.sageserpent.americium.junit5.TrialException]
+    val trialException = failure.asInstanceOf[com.sageserpent.americium.junit5.TrialException]
+    val recipe = trialException.recipe
+    val recipeHash = trialException.recipeHash
+
+    recipe should not be empty
+    recipeHash should not be empty
+    trialException.toString should include("Reproduce via Java property:")
+    trialException.toString should include("trials.recipeHash=")
+
+    // Now test replay with trials.recipe
+    System.setProperty("trials.recipe", recipe)
+    try {
+      val replayResults = EngineTestKit.engine("junit-jupiter")
+        .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
+        .configurationParameter(
+          "junit.jupiter.conditions.deactivate",
+          "org.junit.*DisabledCondition"
+        )
+        .execute()
+
+      val replayEvents = replayResults.testEvents()
+      replayEvents.started().count() shouldBe 1
+      replayEvents.failed().count() shouldBe 1
+    } finally {
+      System.clearProperty("trials.recipe")
+    }
+
+    // Now test replay with trials.recipeHash
+    System.setProperty("trials.recipeHash", recipeHash)
+    try {
+      val replayResults = EngineTestKit.engine("junit-jupiter")
+        .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
+        .configurationParameter(
+          "junit.jupiter.conditions.deactivate",
+          "org.junit.*DisabledCondition"
+        )
+        .execute()
+
+      val replayEvents = replayResults.testEvents()
+      replayEvents.started().count() shouldBe 1
+      replayEvents.failed().count() shouldBe 1
+    } finally {
+      System.clearProperty("trials.recipeHash")
+    }
+  }
+}
+
+@org.junit.jupiter.api.Disabled
+class FailingDynamicTestExample {
+  @TestFactory
+  def failingTest(): DynamicTests = {
+    Trials.api.integers(1, 10).withLimit(5).dynamicTests { caze =>
+      if (caze == 1) {
+        throw new RuntimeException("Deliberate failure for caze 1")
+      }
+    }
+  }
+}

--- a/junit5-integration/src/test/scala/com/sageserpent/americium/junit5/JUnit5FailureAndReplaySpec.scala
+++ b/junit5-integration/src/test/scala/com/sageserpent/americium/junit5/JUnit5FailureAndReplaySpec.scala
@@ -7,39 +7,14 @@ import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.testkit.engine.EngineTestKit
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 
-class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
+class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks {
   "running a failing dynamicTest under JUnit5" should "produce com.sageserpent.americium.junit5.TrialException with recipe/recipeId diagnostics and support replay" in {
-    // Set a different failing case to prove we can vary which case fails dynamically!
-    FailingDynamicTestExample.failingCase = 3
+    forAll(Table("failingCase", 1, 2, 3, 4, 5)) { failingCase =>
+      FailingDynamicTestExample.failingCase = failingCase
 
-    val results = EngineTestKit.engine("junit-jupiter")
-      .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
-      .configurationParameter(
-        "junit.jupiter.conditions.deactivate",
-        "org.junit.*DisabledCondition"
-      )
-      .execute()
-
-    val testEvents = results.testEvents()
-    val failedTests = testEvents.failed().list()
-    failedTests should not be empty
-
-    val failure = failedTests.get(0).getRequiredPayload(classOf[org.junit.platform.engine.TestExecutionResult]).getThrowable.get()
-    failure shouldBe a[com.sageserpent.americium.junit5.TrialException]
-    val trialException = failure.asInstanceOf[com.sageserpent.americium.junit5.TrialException]
-    val recipe = trialException.recipe
-    val recipeHash = trialException.recipeHash
-
-    recipe should not be empty
-    recipeHash should not be empty
-    trialException.toString should include("Reproduce via Java property:")
-    trialException.toString should include("trials.recipeHash=")
-
-    // Now test replay with trials.recipe
-    System.setProperty("trials.recipe", recipe)
-    try {
-      val replayResults = EngineTestKit.engine("junit-jupiter")
+      val results = EngineTestKit.engine("junit-jupiter")
         .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
         .configurationParameter(
           "junit.jupiter.conditions.deactivate",
@@ -47,63 +22,64 @@ class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
         )
         .execute()
 
-      val replayEvents = replayResults.testEvents()
-      replayEvents.started().count() shouldBe 1
-      replayEvents.failed().count() shouldBe 1
-    } finally {
-      System.clearProperty("trials.recipe")
-    }
+      val testEvents = results.testEvents()
+      val failedTests = testEvents.failed().list()
+      failedTests should not be empty
 
-    // Now test replay with trials.recipeHash
-    System.setProperty("trials.recipeHash", recipeHash)
-    try {
-      val replayResults = EngineTestKit.engine("junit-jupiter")
-        .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
-        .configurationParameter(
-          "junit.jupiter.conditions.deactivate",
-          "org.junit.*DisabledCondition"
-        )
-        .execute()
+      val failure = failedTests.get(0).getRequiredPayload(classOf[org.junit.platform.engine.TestExecutionResult]).getThrowable.get()
+      failure shouldBe a[com.sageserpent.americium.junit5.TrialException]
+      val trialException = failure.asInstanceOf[com.sageserpent.americium.junit5.TrialException]
+      val recipe = trialException.recipe
+      val recipeHash = trialException.recipeHash
 
-      val replayEvents = replayResults.testEvents()
-      replayEvents.started().count() shouldBe 1
-      replayEvents.failed().count() shouldBe 1
-    } finally {
-      System.clearProperty("trials.recipeHash")
+      recipe should not be empty
+      recipeHash should not be empty
+      trialException.toString should include("Reproduce via Java property:")
+      trialException.toString should include("trials.recipeHash=")
+
+      // Now test replay with trials.recipe
+      System.setProperty("trials.recipe", recipe)
+      try {
+        val replayResults = EngineTestKit.engine("junit-jupiter")
+          .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
+          .configurationParameter(
+            "junit.jupiter.conditions.deactivate",
+            "org.junit.*DisabledCondition"
+          )
+          .execute()
+
+        val replayEvents = replayResults.testEvents()
+        replayEvents.started().count() shouldBe 1
+        replayEvents.failed().count() shouldBe 1
+      } finally {
+        System.clearProperty("trials.recipe")
+      }
+
+      // Now test replay with trials.recipeHash
+      System.setProperty("trials.recipeHash", recipeHash)
+      try {
+        val replayResults = EngineTestKit.engine("junit-jupiter")
+          .selectors(DiscoverySelectors.selectClass(classOf[FailingDynamicTestExample]))
+          .configurationParameter(
+            "junit.jupiter.conditions.deactivate",
+            "org.junit.*DisabledCondition"
+          )
+          .execute()
+
+        val replayEvents = replayResults.testEvents()
+        replayEvents.started().count() shouldBe 1
+        replayEvents.failed().count() shouldBe 1
+      } finally {
+        System.clearProperty("trials.recipeHash")
+      }
     }
   }
 
   "running a failing annotated TrialsTest under JUnit5" should "produce com.sageserpent.americium.junit5.TrialException with recipe/recipeId diagnostics and support replay" in {
-    // Set a different failing case to prove we can vary which case fails dynamically!
-    FailingTrialsTestExample.failingCase = 4
+    forAll(Table("failingCase", 1, 2, 3, 4, 5)) { failingCase =>
+      FailingTrialsTestExample.failingCase = failingCase
 
-    val results = EngineTestKit.engine("junit-jupiter")
-      .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
-      .configurationParameter(
-        "junit.jupiter.conditions.deactivate",
-        "org.junit.*DisabledCondition"
-      )
-      .execute()
-
-    val testEvents = results.testEvents()
-    val failedTests = testEvents.failed().list()
-    failedTests should not be empty
-
-    val failure = failedTests.get(0).getRequiredPayload(classOf[org.junit.platform.engine.TestExecutionResult]).getThrowable.get()
-    failure shouldBe a[com.sageserpent.americium.junit5.TrialException]
-    val trialException = failure.asInstanceOf[com.sageserpent.americium.junit5.TrialException]
-    val recipe = trialException.recipe
-    val recipeHash = trialException.recipeHash
-
-    recipe should not be empty
-    recipeHash should not be empty
-    trialException.toString should include("Reproduce via Java property:")
-    trialException.toString should include("trials.recipeHash=")
-
-    // Now test replay with trials.recipe
-    System.setProperty("trials.recipe", recipe)
-    try {
-      val replayResults = EngineTestKit.engine("junit-jupiter")
+      val results = EngineTestKit.engine("junit-jupiter")
         .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
         .configurationParameter(
           "junit.jupiter.conditions.deactivate",
@@ -111,29 +87,56 @@ class JUnit5FailureAndReplaySpec extends AnyFlatSpec with Matchers {
         )
         .execute()
 
-      val replayEvents = replayResults.testEvents()
-      replayEvents.started().count() shouldBe 1
-      replayEvents.failed().count() shouldBe 1
-    } finally {
-      System.clearProperty("trials.recipe")
-    }
+      val testEvents = results.testEvents()
+      val failedTests = testEvents.failed().list()
+      failedTests should not be empty
 
-    // Now test replay with trials.recipeHash
-    System.setProperty("trials.recipeHash", recipeHash)
-    try {
-      val replayResults = EngineTestKit.engine("junit-jupiter")
-        .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
-        .configurationParameter(
-          "junit.jupiter.conditions.deactivate",
-          "org.junit.*DisabledCondition"
-        )
-        .execute()
+      val failure = failedTests.get(0).getRequiredPayload(classOf[org.junit.platform.engine.TestExecutionResult]).getThrowable.get()
+      failure shouldBe a[com.sageserpent.americium.junit5.TrialException]
+      val trialException = failure.asInstanceOf[com.sageserpent.americium.junit5.TrialException]
+      val recipe = trialException.recipe
+      val recipeHash = trialException.recipeHash
 
-      val replayEvents = replayResults.testEvents()
-      replayEvents.started().count() shouldBe 1
-      replayEvents.failed().count() shouldBe 1
-    } finally {
-      System.clearProperty("trials.recipeHash")
+      recipe should not be empty
+      recipeHash should not be empty
+      trialException.toString should include("Reproduce via Java property:")
+      trialException.toString should include("trials.recipeHash=")
+
+      // Now test replay with trials.recipe
+      System.setProperty("trials.recipe", recipe)
+      try {
+        val replayResults = EngineTestKit.engine("junit-jupiter")
+          .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
+          .configurationParameter(
+            "junit.jupiter.conditions.deactivate",
+            "org.junit.*DisabledCondition"
+          )
+          .execute()
+
+        val replayEvents = replayResults.testEvents()
+        replayEvents.started().count() shouldBe 1
+        replayEvents.failed().count() shouldBe 1
+      } finally {
+        System.clearProperty("trials.recipe")
+      }
+
+      // Now test replay with trials.recipeHash
+      System.setProperty("trials.recipeHash", recipeHash)
+      try {
+        val replayResults = EngineTestKit.engine("junit-jupiter")
+          .selectors(DiscoverySelectors.selectClass(classOf[FailingTrialsTestExample]))
+          .configurationParameter(
+            "junit.jupiter.conditions.deactivate",
+            "org.junit.*DisabledCondition"
+          )
+          .execute()
+
+        val replayEvents = replayResults.testEvents()
+        replayEvents.started().count() shouldBe 1
+        replayEvents.failed().count() shouldBe 1
+      } finally {
+        System.clearProperty("trials.recipeHash")
+      }
     }
   }
 }


### PR DESCRIPTION
Modified both JUnit5 integrations (the `@TestFactory` `dynamicTests` and the `@TrialsTest` / `TrialsTestExtension`) so that individual test failures are wrapped and reported as `com.sageserpent.americium.junit5.TrialException` containing recipe and recipe hash diagnostics. This enables easy reproduction and matches the behavior of core Americium. Also added comprehensive tests (`JUnit5FailureAndReplaySpec`) using JUnit5 `EngineTestKit` to verify diagnostics and replay via JVM system properties (`trials.recipe` and `trials.recipeHash`).

---
*PR created automatically by Jules for task [14466978240470660415](https://jules.google.com/task/14466978240470660415) started by @sageserpent-open*